### PR TITLE
Add WMM2025 precision validation tests (#4)

### DIFF
--- a/docs/features/4-wmm2025-validation/tasks.md
+++ b/docs/features/4-wmm2025-validation/tasks.md
@@ -13,4 +13,4 @@ Branch: feature/4-wmm2025-validation-tests
 - [x] All tasks checked
 - [x] Build succeeds
 - [x] Tests pass
-- [ ] 2 clean Ralph Loop cycles
+- [x] 2 clean Ralph Loop cycles


### PR DESCRIPTION
## Summary
- 24 parameterized NOAA WMM2025 validation tests (12 main field + 12 secular variation)
- Tests against official NOAA test values from WMM2025 release (Dec 2024)
- Tolerances: ±1.0 nT for intensity, ±0.01° for angles
- All 24 tests pass within tolerance

## Test Coverage
- Two epochs: 2025.0 and 2027.5
- Two altitudes: 0 km and 100 km
- Three locations: 80°N/0°E, 0°N/120°E, 80°S/240°E
- Both main field and secular variation

## References
- PDF: NOAA WMM2025 test values
- TXT: NOAA WMM2025_TEST_VALUES.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)