### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <Authors>Christopher Strecker</Authors>
     <Company>Christopher Strecker</Company>
     <Product>GeoMagSharp</Product>


### PR DESCRIPTION
## Summary
- Bump `VersionPrefix` from 1.5.0 → 1.6.0 in `Directory.Build.props`
- v1.5.0 has been released and tagged — all subsequent builds must use a higher version

## Test plan
- [ ] Build succeeds with new version number

🤖 Generated with [Claude Code](https://claude.com/claude-code)