### PR TITLE
feat: Add dipole depth correction (SPE-128217-MS) - Issue #3

### DIFF
--- a/docs/features/3-depth-adjusted-field/tasks.md
+++ b/docs/features/3-depth-adjusted-field/tasks.md
@@ -16,5 +16,5 @@ Branch: feature/3-depth-adjusted-field
 ## Completion Criteria
 - [x] All tasks checked
 - [x] Build succeeds
-- [x] Tests pass (34 depth correction tests: 27 unit + 7 integration)
+- [x] Tests pass (42 depth correction tests: 35 unit + 7 integration)
 - [ ] 2 clean Ralph Loop cycles

--- a/docs/features/3-depth-adjusted-field/tasks.md
+++ b/docs/features/3-depth-adjusted-field/tasks.md
@@ -1,0 +1,20 @@
+# Feature: Depth-Adjusted Magnetic Field Values (SPE-128217-MS)
+Issue: #3
+Branch: feature/3-depth-adjusted-field
+
+## Tasks
+- [x] Task 1: Create DepthCorrectionResult model class
+- [x] Task 2: Create DepthCorrection static class with dipole math (Eq 1-8)
+- [x] Task 3: Add tool-frame error and boundary unit tests
+- [x] Task 4: Add MagneticCalculations convenience overload
+- [x] Task 5: Add SurveyDepthMeters, WellboreAzimuthDeg, WellboreInclinationDeg to CalculationOptions
+- [x] Task 6: Add DepthCorrection property to MagneticCalculations; Add DepthAzimuthUncertainty to GeomagneticUncertainty
+- [x] Task 7: Integrate depth correction into GeoMag sync and async pipelines
+- [x] Task 8: Add 7 integration tests with WMM2025 model
+- [x] Task 9: Create tasks.md, push branch, create draft PR
+
+## Completion Criteria
+- [x] All tasks checked
+- [x] Build succeeds
+- [x] Tests pass (34 depth correction tests: 27 unit + 7 integration)
+- [ ] 2 clean Ralph Loop cycles

--- a/docs/features/3-depth-adjusted-field/tasks.md
+++ b/docs/features/3-depth-adjusted-field/tasks.md
@@ -17,4 +17,4 @@ Branch: feature/3-depth-adjusted-field
 - [x] All tasks checked
 - [x] Build succeeds
 - [x] Tests pass (42 depth correction tests: 35 unit + 7 integration)
-- [ ] 2 clean Ralph Loop cycles
+- [x] 2 clean Ralph Loop cycles

--- a/docs/superpowers/plans/2026-03-11-depth-adjusted-field.md
+++ b/docs/superpowers/plans/2026-03-11-depth-adjusted-field.md
@@ -1,0 +1,1073 @@
+# Depth-Adjusted Magnetic Field Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add depth-adjusted magnetic field values and depth-dependent uncertainty per SPE-128217-MS, with both standalone and pipeline-integrated API.
+
+**Architecture:** Post-processing layer that takes surface field results and applies dipole depth correction equations (Eq 1-8). New `DepthCorrection` static class handles all math. Results attached to existing `MagneticCalculations` via nullable `DepthCorrection` property. Depth uncertainty added to existing `GeomagneticUncertainty` class.
+
+**Tech Stack:** C# (.NET Framework 4.8 / .NET Standard 2.0), MSTest, GeoMagSharp library
+
+**Spec:** `docs/superpowers/specs/2026-03-11-depth-adjusted-field-design.md`
+
+---
+
+## Chunk 1: Result Class and Core Math
+
+### Task 1: Create DepthCorrectionResult class
+
+**Files:**
+- Create: `src/GeoMagSharp/Models/Results/DepthCorrectionResult.cs`
+
+- [ ] **Step 1: Create the result class**
+
+```csharp
+/****************************************************************************
+ * File:            DepthCorrectionResult.cs
+ * Description:     Result class for dipole depth correction (SPE-128217-MS)
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ ****************************************************************************/
+
+namespace GeoMagSharp
+{
+    /// <summary>
+    /// Results of dipole depth correction per SPE-128217-MS (Ekseth &amp; Weston, 2010).
+    /// Null tool-frame and azimuth error properties indicate wellbore geometry was not provided.
+    /// </summary>
+    public class DepthCorrectionResult
+    {
+        /// <summary>Dipole scaling factor: R³/(R-D)³</summary>
+        public double DipoleScalingFactor { get; set; }
+
+        /// <summary>Horizontal intensity at depth (nT), Eq 1</summary>
+        public double HorizontalIntensityAtDepth { get; set; }
+
+        /// <summary>Vertical intensity at depth (nT), Eq 2</summary>
+        public double VerticalIntensityAtDepth { get; set; }
+
+        /// <summary>Total field at depth (nT), derived from Eq 1-2</summary>
+        public double TotalFieldAtDepth { get; set; }
+
+        /// <summary>Horizontal field error from using surface values (nT), Eq 3</summary>
+        public double HorizontalError { get; set; }
+
+        /// <summary>Vertical field error from using surface values (nT), Eq 4</summary>
+        public double VerticalError { get; set; }
+
+        /// <summary>High-side error component (nT), Eq 5. Null if no wellbore geometry.</summary>
+        public double? HighSideError { get; set; }
+
+        /// <summary>High-side-right error component (nT), Eq 6. Null if no wellbore geometry.</summary>
+        public double? HighSideRightError { get; set; }
+
+        /// <summary>Along-hole error component (nT), Eq 7. Null if no wellbore geometry.</summary>
+        public double? AlongHoleError { get; set; }
+
+        /// <summary>Azimuth error estimate (degrees), Eq 8. Null if no wellbore geometry.</summary>
+        public double? AzimuthErrorDeg { get; set; }
+
+        /// <summary>Singularity proximity: (1 - sin²A·sin²I). Values near 0 indicate E-W singularity.</summary>
+        public double? SingularityFactor { get; set; }
+
+        /// <summary>True when SingularityFactor &lt; 0.1, indicating Eq 8 is unreliable.</summary>
+        public bool? NearSingularity { get; set; }
+
+        /// <summary>Geomagnetic latitude (degrees), derived from field: atan(Bv / 2Bh)</summary>
+        public double GeomagneticLatitudeDeg { get; set; }
+
+        /// <summary>Survey depth below surface (meters)</summary>
+        public double DepthMeters { get; set; }
+
+        /// <summary>Reference paper identifier</summary>
+        public string Reference { get; set; }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+Run: `dotnet build -c Release`
+Expected: Build succeeded. 0 Error(s)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/GeoMagSharp/Models/Results/DepthCorrectionResult.cs
+git commit -m "feat: add DepthCorrectionResult class for SPE-128217 depth corrections"
+```
+
+---
+
+### Task 2: Create DepthCorrection static class with core dipole math
+
+**Files:**
+- Create: `src/GeoMagSharp/DepthCorrection.cs`
+- Test: `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs`
+
+- [ ] **Step 1: Write failing tests for input validation and dipole scaling**
+
+Create `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs`:
+
+```csharp
+/****************************************************************************
+ * File:            DepthCorrectionUnitTest.cs
+ * Description:     Tests for dipole depth correction (SPE-128217-MS)
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ ****************************************************************************/
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using GeoMagSharp;
+
+namespace GeoMagSharp_UnitTests
+{
+    [TestClass]
+    public class DepthCorrectionUnitTest
+    {
+        // Worked example from spec: B_h=20000, B_v=40000, D=3000m, A=45°, I=60°
+        private const double Bh = 20000.0;
+        private const double Bv = 40000.0;
+        private const double F = 44721.36; // sqrt(20000² + 40000²)
+        private const double DepthM = 3000.0;
+        private const double Azimuth = 45.0;
+        private const double Inclination = 60.0;
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_NegativeDepth_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, -100);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_ZeroEarthRadius_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, DepthM, earthRadiusKm: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_InclinationOutOfRange_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, DepthM, wellboreAzimuthDeg: 45, wellboreInclinationDeg: 200);
+        }
+
+        [TestMethod]
+        public void Calculate_ZeroDepth_ReturnsIdentity()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, 0);
+
+            Assert.AreEqual(1.0, result.DipoleScalingFactor, 1e-10);
+            Assert.AreEqual(Bh, result.HorizontalIntensityAtDepth, 0.01);
+            Assert.AreEqual(Bv, result.VerticalIntensityAtDepth, 0.01);
+            Assert.AreEqual(0.0, result.HorizontalError, 1e-10);
+            Assert.AreEqual(0.0, result.VerticalError, 1e-10);
+        }
+
+        [TestMethod]
+        public void Calculate_1kmDepth_CorrectScalingFactor()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, 1000);
+
+            // R³/(R-D)³ where R=6371200m, D=1000m
+            double R = Constants.EarthsRadiusInKm * 1000;
+            double expected = Math.Pow(R / (R - 1000), 3);
+            Assert.AreEqual(expected, result.DipoleScalingFactor, 1e-8);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_GeomagneticLatitude()
+        {
+            // B_h=20000, B_v=40000 → φ = atan(40000/(2*20000)) = atan(1) = 45°
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(45.0, result.GeomagneticLatitudeDeg, 0.01);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_HorizontalError()
+        {
+            // Eq 3: ΔB_h = 3·B₀·cos(φ)·D/R
+            // B₀ = 20000/cos(45°) = 28284.3, ΔB_h = 3·28284.3·cos(45°)·3000/6371200 ≈ 28.2 nT
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(28.2, result.HorizontalError, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_VerticalError()
+        {
+            // Eq 4: ΔB_v = 6·B₀·sin(φ)·D/R ≈ 56.5 nT
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(56.5, result.VerticalError, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_FieldAtDepth()
+        {
+            // B_h(D) ≈ 20028.3, B_v(D) ≈ 40056.5
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(20028.3, result.HorizontalIntensityAtDepth, 1.0);
+            Assert.AreEqual(40056.5, result.VerticalIntensityAtDepth, 1.0);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_TotalFieldAtDepth()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            double expectedF = F * result.DipoleScalingFactor;
+            Assert.AreEqual(expectedF, result.TotalFieldAtDepth, 0.1);
+            // Also verify it equals sqrt(Bh² + Bv²) at depth
+            double fromComponents = Math.Sqrt(
+                result.HorizontalIntensityAtDepth * result.HorizontalIntensityAtDepth +
+                result.VerticalIntensityAtDepth * result.VerticalIntensityAtDepth);
+            Assert.AreEqual(fromComponents, result.TotalFieldAtDepth, 0.1);
+        }
+
+        [TestMethod]
+        public void Calculate_NullWellboreGeometry_SkipsToolFrameAndAzimuth()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+
+            Assert.IsNull(result.HighSideError);
+            Assert.IsNull(result.HighSideRightError);
+            Assert.IsNull(result.AlongHoleError);
+            Assert.IsNull(result.AzimuthErrorDeg);
+            Assert.IsNull(result.SingularityFactor);
+            Assert.IsNull(result.NearSingularity);
+        }
+
+        [TestMethod]
+        public void Calculate_ZeroHorizontalIntensity_MagneticPole()
+        {
+            // At magnetic pole, B_h ≈ 0, B_v is large
+            var result = DepthCorrection.Calculate(0.1, 60000, 60000, DepthM);
+            Assert.AreEqual(90.0, result.GeomagneticLatitudeDeg, 1.0);
+        }
+
+        [TestMethod]
+        public void Calculate_Reference_AlwaysSPE128217()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual("SPE-128217-MS", result.Reference);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: FAIL — `DepthCorrection` class does not exist
+
+- [ ] **Step 3: Implement DepthCorrection.Calculate (primitive overload)**
+
+Create `src/GeoMagSharp/DepthCorrection.cs`:
+
+```csharp
+/****************************************************************************
+ * File:            DepthCorrection.cs
+ * Description:     Dipole depth correction per SPE-128217-MS
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ * Notes:           Reference: SPE-128217-MS (Ekseth & Weston, Gyrodata, 2010)
+ *                  "Wellbore Positions Obtained While Drilling by the Most
+ *                  Advanced Magnetic Surveying Methods May Be Less Accurate
+ *                  than Predicted"
+ ****************************************************************************/
+
+using System;
+
+namespace GeoMagSharp
+{
+    /// <summary>
+    /// Calculates dipole depth corrections for geomagnetic field values
+    /// per SPE-128217-MS (Ekseth &amp; Weston, 2010).
+    /// </summary>
+    public static class DepthCorrection
+    {
+        private const double SingularityThreshold = 0.1;
+        private const double HorizontalIntensityPoleThreshold = 1.0; // nT
+        private const double DegToRad = Math.PI / 180.0;
+        private const double RadToDeg = 180.0 / Math.PI;
+
+        /// <summary>
+        /// Calculate depth correction from surface field values using dipole approximation.
+        /// </summary>
+        /// <param name="horizontalIntensityNT">Surface horizontal intensity B_h (nT)</param>
+        /// <param name="verticalIntensityNT">Surface vertical intensity B_v (nT, positive downward)</param>
+        /// <param name="totalFieldNT">Surface total field F (nT)</param>
+        /// <param name="depthMeters">Survey depth below surface (meters, must be >= 0)</param>
+        /// <param name="wellboreAzimuthDeg">Magnetic azimuth (degrees, 0-360). Null to skip Eq 5-8.</param>
+        /// <param name="wellboreInclinationDeg">Wellbore inclination (degrees, 0-180). Null to skip Eq 5-8.</param>
+        /// <param name="earthRadiusKm">Earth radius (km). Default: Constants.EarthsRadiusInKm</param>
+        public static DepthCorrectionResult Calculate(
+            double horizontalIntensityNT,
+            double verticalIntensityNT,
+            double totalFieldNT,
+            double depthMeters,
+            double? wellboreAzimuthDeg = null,
+            double? wellboreInclinationDeg = null,
+            double earthRadiusKm = Constants.EarthsRadiusInKm)
+        {
+            if (depthMeters < 0)
+                throw new ArgumentOutOfRangeException(nameof(depthMeters), "Depth must be >= 0");
+            if (earthRadiusKm <= 0)
+                throw new ArgumentOutOfRangeException(nameof(earthRadiusKm), "Earth radius must be > 0");
+            if (wellboreInclinationDeg.HasValue && (wellboreInclinationDeg.Value < 0 || wellboreInclinationDeg.Value > 180))
+                throw new ArgumentOutOfRangeException(nameof(wellboreInclinationDeg), "Inclination must be 0-180 degrees");
+
+            double earthRadiusM = earthRadiusKm * 1000.0;
+
+            // Geomagnetic latitude: φ = atan(Bv / (2·Bh))
+            double geomagLatRad;
+            if (Math.Abs(horizontalIntensityNT) < HorizontalIntensityPoleThreshold)
+            {
+                geomagLatRad = Math.PI / 2.0; // 90° at magnetic pole
+            }
+            else
+            {
+                geomagLatRad = Math.Atan2(verticalIntensityNT, 2.0 * horizontalIntensityNT);
+            }
+
+            double cosPhi = Math.Cos(geomagLatRad);
+            double sinPhi = Math.Sin(geomagLatRad);
+
+            // Equatorial dipole field: B₀ = Bh / cos(φ)
+            double B0 = Math.Abs(cosPhi) > 1e-10
+                ? horizontalIntensityNT / cosPhi
+                : verticalIntensityNT / (2.0 * sinPhi);
+
+            // Dipole scaling factor: R³/(R-D)³
+            double scalingFactor = Math.Pow(earthRadiusM / (earthRadiusM - depthMeters), 3);
+
+            // Field at depth (Eq 1-2)
+            double bhAtDepth = horizontalIntensityNT * scalingFactor;
+            double bvAtDepth = verticalIntensityNT * scalingFactor;
+            double fAtDepth = totalFieldNT * scalingFactor;
+
+            // Field errors (Eq 3-4): first-order approximation
+            double dOverR = depthMeters / earthRadiusM;
+            double deltaH = 3.0 * B0 * cosPhi * dOverR;
+            double deltaV = 6.0 * B0 * sinPhi * dOverR;
+
+            var result = new DepthCorrectionResult
+            {
+                DipoleScalingFactor = scalingFactor,
+                HorizontalIntensityAtDepth = bhAtDepth,
+                VerticalIntensityAtDepth = bvAtDepth,
+                TotalFieldAtDepth = fAtDepth,
+                HorizontalError = deltaH,
+                VerticalError = deltaV,
+                GeomagneticLatitudeDeg = geomagLatRad * RadToDeg,
+                DepthMeters = depthMeters,
+                Reference = "SPE-128217-MS"
+            };
+
+            // Tool-frame errors and azimuth error (Eq 5-8) — requires wellbore geometry
+            if (wellboreAzimuthDeg.HasValue && wellboreInclinationDeg.HasValue)
+            {
+                double A = (wellboreAzimuthDeg.Value % 360.0) * DegToRad;
+                double I = wellboreInclinationDeg.Value * DegToRad;
+
+                double cosA = Math.Cos(A);
+                double sinA = Math.Sin(A);
+                double cosI = Math.Cos(I);
+                double sinI = Math.Sin(I);
+
+                // Eq 5: ΔB_H (high-side)
+                result.HighSideError = 3.0 * B0 * (cosPhi * cosA * cosI - 2.0 * sinPhi * sinI) * dOverR;
+
+                // Eq 6: ΔB_R (high-side-right)
+                result.HighSideRightError = -3.0 * B0 * cosPhi * sinA * dOverR;
+
+                // Eq 7: ΔB_A (along-hole)
+                result.AlongHoleError = 3.0 * B0 * (cosPhi * cosA * sinI + 2.0 * sinPhi * cosI) * dOverR;
+
+                // Singularity factor: (1 - sin²A·sin²I)
+                double singFactor = 1.0 - sinA * sinA * sinI * sinI;
+                result.SingularityFactor = singFactor;
+                result.NearSingularity = singFactor < SingularityThreshold;
+
+                // Eq 8: ΔA (azimuth error)
+                double sin2A = Math.Sin(2.0 * A);
+                double sin2I = Math.Sin(2.0 * I);
+                double tanPhi = Math.Abs(cosPhi) > 1e-10 ? sinPhi / cosPhi : 1e10;
+
+                double numerator = (sin2A * sinI * sinI + 2.0 * tanPhi * sinA * sin2I) * 1.5 * dOverR;
+                double azErrorRad = Math.Abs(singFactor) > 1e-10
+                    ? numerator / singFactor
+                    : numerator / 1e-10; // Avoid division by zero
+
+                result.AzimuthErrorDeg = azErrorRad * RadToDeg;
+            }
+
+            return result;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All DepthCorrectionUnitTest tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/GeoMagSharp/DepthCorrection.cs tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+git commit -m "feat: add DepthCorrection class with dipole math (Eq 1-8)"
+```
+
+---
+
+### Task 3: Add tool-frame and boundary tests
+
+**Files:**
+- Modify: `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs`
+
+- [ ] **Step 1: Add tool-frame, singularity, and boundary tests**
+
+Append to `DepthCorrectionUnitTest` class:
+
+```csharp
+        [TestMethod]
+        public void Calculate_WorkedExample_ToolFrameErrors()
+        {
+            // A=45°, I=60°, D=3000m, B₀=28284.3, φ=45°
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            Assert.IsNotNull(result.HighSideError);
+            Assert.IsNotNull(result.HighSideRightError);
+            Assert.IsNotNull(result.AlongHoleError);
+
+            // Eq 5: 3·B₀·(cos45·cos45·cos60 - 2·sin45·sin60)·D/R
+            double B0 = 28284.3;
+            double dOverR = 3000.0 / (Constants.EarthsRadiusInKm * 1000);
+            double cos45 = Math.Cos(45 * Math.PI / 180);
+            double sin45 = Math.Sin(45 * Math.PI / 180);
+            double cos60 = Math.Cos(60 * Math.PI / 180);
+            double sin60 = Math.Sin(60 * Math.PI / 180);
+
+            double expectedH = 3 * B0 * (cos45 * cos45 * cos60 - 2 * sin45 * sin60) * dOverR;
+            double expectedR = -3 * B0 * cos45 * sin45 * dOverR;
+            double expectedA = 3 * B0 * (cos45 * cos45 * sin60 + 2 * sin45 * cos60) * dOverR;
+
+            Assert.AreEqual(expectedH, result.HighSideError.Value, 0.5);
+            Assert.AreEqual(expectedR, result.HighSideRightError.Value, 0.5);
+            Assert.AreEqual(expectedA, result.AlongHoleError.Value, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_AzimuthError()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            // From spec worked example: ΔA ≈ 0.128°
+            Assert.IsNotNull(result.AzimuthErrorDeg);
+            Assert.AreEqual(0.128, result.AzimuthErrorDeg.Value, 0.01);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_SingularityFactor()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            // 1 - sin²(45)·sin²(60) = 1 - 0.5·0.75 = 0.625
+            Assert.AreEqual(0.625, result.SingularityFactor.Value, 0.001);
+            Assert.IsFalse(result.NearSingularity.Value);
+        }
+
+        [TestMethod]
+        public void Calculate_NearEastWest_HighInclination_FlagsSingularity()
+        {
+            // A=90° (east), I=85° → singFactor = 1 - sin²(90)·sin²(85) ≈ 1 - 0.9924 = 0.0076
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 90, wellboreInclinationDeg: 85);
+
+            Assert.IsTrue(result.NearSingularity.Value);
+            Assert.IsTrue(result.SingularityFactor.Value < 0.1);
+        }
+
+        [TestMethod]
+        public void Calculate_VerticalWell_ToolFrameErrors()
+        {
+            // I=0° (vertical): cosI=1, sinI=0
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 0, wellboreInclinationDeg: 0);
+
+            // Eq 6: ΔB_R = -3·B₀·cos(φ)·sin(0)·D/R = 0
+            Assert.AreEqual(0.0, result.HighSideRightError.Value, 0.01);
+            // Eq 8: sin(2A)=0, sin(2I)=0 → ΔA = 0
+            Assert.AreEqual(0.0, result.AzimuthErrorDeg.Value, 0.001);
+        }
+
+        [TestMethod]
+        public void Calculate_NorthAzimuth_ToolFrameErrors()
+        {
+            // A=0° (north): sinA=0
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 0, wellboreInclinationDeg: Inclination);
+
+            // Eq 6: ΔB_R = -3·B₀·cos(φ)·sin(0)·D/R = 0
+            Assert.AreEqual(0.0, result.HighSideRightError.Value, 0.01);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+git commit -m "test: add tool-frame, singularity, and boundary tests for depth correction"
+```
+
+---
+
+## Chunk 2: Convenience Overload and Input Properties
+
+### Task 4: Add MagneticCalculations convenience overload
+
+**Files:**
+- Modify: `src/GeoMagSharp/DepthCorrection.cs`
+- Modify: `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs`
+
+- [ ] **Step 1: Write failing test for convenience overload**
+
+Append to `DepthCorrectionUnitTest`:
+
+```csharp
+        [TestMethod]
+        public void Calculate_ConvenienceOverload_MatchesPrimitive()
+        {
+            // Create a MagneticCalculations with known values
+            var magCalc = new MagneticCalculations
+            {
+                HorizontalIntensity = new MagneticValue { Value = Bh },
+                VerticalComp = new MagneticValue { Value = Bv },
+                TotalField = new MagneticValue { Value = F }
+            };
+
+            var fromPrimitive = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+            var fromOverload = DepthCorrection.Calculate(magCalc, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            Assert.AreEqual(fromPrimitive.DipoleScalingFactor, fromOverload.DipoleScalingFactor, 1e-10);
+            Assert.AreEqual(fromPrimitive.HorizontalIntensityAtDepth, fromOverload.HorizontalIntensityAtDepth, 0.01);
+            Assert.AreEqual(fromPrimitive.VerticalIntensityAtDepth, fromOverload.VerticalIntensityAtDepth, 0.01);
+            Assert.AreEqual(fromPrimitive.AzimuthErrorDeg.Value, fromOverload.AzimuthErrorDeg.Value, 1e-10);
+        }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: FAIL — overload does not exist
+
+- [ ] **Step 3: Implement the convenience overload**
+
+Add to `DepthCorrection` class:
+
+```csharp
+        /// <summary>
+        /// Convenience overload accepting MagneticCalculations directly.
+        /// Extracts HorizontalIntensity, VerticalComp, and TotalField values.
+        /// </summary>
+        public static DepthCorrectionResult Calculate(
+            MagneticCalculations surfaceField,
+            double depthMeters,
+            double? wellboreAzimuthDeg = null,
+            double? wellboreInclinationDeg = null)
+        {
+            if (surfaceField == null)
+                throw new ArgumentNullException(nameof(surfaceField));
+
+            return Calculate(
+                surfaceField.HorizontalIntensity.Value,
+                surfaceField.VerticalComp.Value,
+                surfaceField.TotalField.Value,
+                depthMeters,
+                wellboreAzimuthDeg,
+                wellboreInclinationDeg);
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/GeoMagSharp/DepthCorrection.cs tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+git commit -m "feat: add MagneticCalculations convenience overload to DepthCorrection"
+```
+
+---
+
+### Task 5: Add SurveyDepthMeters and wellbore properties to CalculationOptions
+
+**Files:**
+- Modify: `src/GeoMagSharp/Models/Configuration/CalculationOptions.cs`
+
+- [ ] **Step 1: Add properties and update copy constructor**
+
+Add three nullable properties to `CalculationOptions` (after the existing `ModelCategoryOverride` property):
+
+```csharp
+        /// <summary>Survey depth below surface in meters (TVD). Always positive. Null to skip depth correction.</summary>
+        public double? SurveyDepthMeters { get; set; }
+
+        /// <summary>Wellbore magnetic azimuth in degrees (0-360). Required for tool-frame errors (Eq 5-8).</summary>
+        public double? WellboreAzimuth { get; set; }
+
+        /// <summary>Wellbore inclination in degrees (0-180, MWD convention). Required for tool-frame errors (Eq 5-8).</summary>
+        public double? WellboreInclination { get; set; }
+```
+
+In the copy constructor (around line 43-57), add after the `ModelCategoryOverride` copy (line 52):
+
+```csharp
+            SurveyDepthMeters = other.SurveyDepthMeters;
+            WellboreAzimuth = other.WellboreAzimuth;
+            WellboreInclination = other.WellboreInclination;
+```
+
+- [ ] **Step 2: Verify build and all existing tests still pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS (no behavioral change)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
+git commit -m "feat: add SurveyDepthMeters and wellbore geometry to CalculationOptions"
+```
+
+---
+
+### Task 6: Add DepthCorrection property to MagneticCalculations and DepthAzimuthUncertainty to GeomagneticUncertainty
+
+**Files:**
+- Modify: `src/GeoMagSharp/Models/Results/MagneticCalculations.cs`
+- Modify: `src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs`
+
+- [ ] **Step 1: Add DepthCorrection property to MagneticCalculations**
+
+Add property (after `Uncertainty` at line ~153):
+
+```csharp
+        /// <summary>Depth correction results per SPE-128217-MS. Null when no survey depth specified.</summary>
+        public DepthCorrectionResult DepthCorrection { get; set; }
+```
+
+In the copy constructor (around line 39-50), add after `Uncertainty` copy (line 49):
+
+```csharp
+            DepthCorrection = other.DepthCorrection;
+```
+
+- [ ] **Step 2: Add DepthAzimuthUncertainty to GeomagneticUncertainty**
+
+Add property (after `DipAngle` property):
+
+```csharp
+        /// <summary>
+        /// Depth-dependent azimuth uncertainty in degrees (1σ), per SPE-128217-MS.
+        /// When wellbore geometry provided: computed from Eq 8.
+        /// When not provided: 0.38° global average from Monte Carlo.
+        /// Null when no survey depth specified.
+        /// </summary>
+        public double? DepthAzimuthUncertainty { get; set; }
+```
+
+- [ ] **Step 3: Verify build and all existing tests still pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/GeoMagSharp/Models/Results/MagneticCalculations.cs src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
+git commit -m "feat: add DepthCorrection and DepthAzimuthUncertainty properties"
+```
+
+---
+
+## Chunk 3: Pipeline Integration and Integration Tests
+
+### Task 7: Integrate depth correction into GeoMag pipeline
+
+**Files:**
+- Modify: `src/GeoMagSharp/GeoMag.cs`
+
+- [ ] **Step 1: Add depth correction to sync pipeline**
+
+In the sync `MagneticCalculations` method, after the uncertainty attachment (around line 151), add:
+
+```csharp
+                    // Depth correction (SPE-128217-MS) — only when survey depth specified
+                    if (_CalculationOptions.SurveyDepthMeters.HasValue && _CalculationOptions.SurveyDepthMeters.Value > 0)
+                    {
+                        magCalcDate.DepthCorrection = DepthCorrection.Calculate(
+                            magCalcDate,
+                            _CalculationOptions.SurveyDepthMeters.Value,
+                            _CalculationOptions.WellboreAzimuth,
+                            _CalculationOptions.WellboreInclination);
+
+                        // Add depth-dependent uncertainty
+                        if (magCalcDate.Uncertainty != null)
+                        {
+                            magCalcDate.Uncertainty.DepthAzimuthUncertainty =
+                                magCalcDate.DepthCorrection.AzimuthErrorDeg.HasValue
+                                    ? Math.Abs(magCalcDate.DepthCorrection.AzimuthErrorDeg.Value)
+                                    : 0.38; // Global average from SPE-128217 Monte Carlo
+                        }
+                    }
+```
+
+- [ ] **Step 2: Add depth correction to async pipeline**
+
+In the async `MagneticCalculationsAsync` method, after the uncertainty attachment (around line 366), add the same block:
+
+```csharp
+                        // Depth correction (SPE-128217-MS) — only when survey depth specified
+                        if (_CalculationOptions.SurveyDepthMeters.HasValue && _CalculationOptions.SurveyDepthMeters.Value > 0)
+                        {
+                            magCalcDate.DepthCorrection = DepthCorrection.Calculate(
+                                magCalcDate,
+                                _CalculationOptions.SurveyDepthMeters.Value,
+                                _CalculationOptions.WellboreAzimuth,
+                                _CalculationOptions.WellboreInclination);
+
+                            if (magCalcDate.Uncertainty != null)
+                            {
+                                magCalcDate.Uncertainty.DepthAzimuthUncertainty =
+                                    magCalcDate.DepthCorrection.AzimuthErrorDeg.HasValue
+                                        ? Math.Abs(magCalcDate.DepthCorrection.AzimuthErrorDeg.Value)
+                                        : 0.38;
+                            }
+                        }
+```
+
+- [ ] **Step 3: Verify build and all existing tests still pass**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS (depth correction only triggers when SurveyDepthMeters is set)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/GeoMagSharp/GeoMag.cs
+git commit -m "feat: integrate depth correction into sync and async calculation pipeline"
+```
+
+---
+
+### Task 8: Add integration tests
+
+**Files:**
+- Modify: `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs`
+
+- [ ] **Step 1: Add integration tests using WMM2025**
+
+Append to `DepthCorrectionUnitTest` class:
+
+```csharp
+        #region Integration Tests
+
+        private static GeoMag LoadWMM2025()
+        {
+            var possiblePaths = new[]
+            {
+                System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestData"),
+                System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "TestData"),
+                System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "tests", "GeoMagSharp.Tests", "TestData"),
+                @"C:\GitHub\GeoMagSharp\tests\GeoMagSharp.Tests\TestData"
+            };
+
+            foreach (var path in possiblePaths)
+            {
+                var candidate = System.IO.Path.GetFullPath(System.IO.Path.Combine(path, "WMM2025.COF"));
+                if (System.IO.File.Exists(candidate))
+                {
+                    var geoMag = new GeoMag();
+                    geoMag.SetModel(candidate);
+                    return geoMag;
+                }
+            }
+            Assert.Fail("Could not find WMM2025.COF in TestData directory");
+            return null;
+        }
+
+        [TestMethod]
+        public void Pipeline_WithoutDepth_NullCorrection()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1)
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var results = geoMag.MagneticCalculations(options);
+
+            Assert.IsTrue(results.Count > 0);
+            Assert.IsNull(results[0].DepthCorrection, "DepthCorrection should be null when no depth specified");
+        }
+
+        [TestMethod]
+        public void Pipeline_WithDepth_PopulatesCorrection()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 2000
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var results = geoMag.MagneticCalculations(options);
+
+            Assert.IsTrue(results.Count > 0);
+            var dc = results[0].DepthCorrection;
+            Assert.IsNotNull(dc, "DepthCorrection should be populated when depth specified");
+            Assert.AreEqual(2000, dc.DepthMeters, 0.01);
+            Assert.IsTrue(dc.DipoleScalingFactor > 1.0, "Field should be stronger at depth");
+            Assert.IsTrue(dc.HorizontalError > 0, "Horizontal error should be positive");
+            Assert.IsTrue(dc.VerticalError > 0, "Vertical error should be positive");
+            Assert.AreEqual("SPE-128217-MS", dc.Reference);
+        }
+
+        [TestMethod]
+        public void Pipeline_WithWellboreGeometry_HasAzimuthError()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 2000,
+                WellboreAzimuth = 45,
+                WellboreInclination = 60
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var results = geoMag.MagneticCalculations(options);
+
+            var dc = results[0].DepthCorrection;
+            Assert.IsNotNull(dc.AzimuthErrorDeg, "Azimuth error should be computed when wellbore geometry provided");
+            Assert.IsNotNull(dc.SingularityFactor);
+            Assert.IsNotNull(dc.HighSideError);
+        }
+
+        [TestMethod]
+        public void Pipeline_DepthUncertainty_AddedToUncertainty()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 2000
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var results = geoMag.MagneticCalculations(options);
+
+            Assert.IsNotNull(results[0].Uncertainty);
+            Assert.IsNotNull(results[0].Uncertainty.DepthAzimuthUncertainty,
+                "DepthAzimuthUncertainty should be populated when depth specified");
+            Assert.AreEqual(0.38, results[0].Uncertainty.DepthAzimuthUncertainty.Value, 0.01,
+                "Without wellbore geometry, should use 0.38° global average");
+        }
+
+        [TestMethod]
+        public void Pipeline_DateRange_AllStepsGetDepthCorrection()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1),
+                EndDate = new DateTime(2025, 7, 1),
+                StepInterval = 3,
+                SurveyDepthMeters = 1500
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var results = geoMag.MagneticCalculations(options);
+
+            Assert.IsTrue(results.Count > 1, "Should have multiple date steps");
+            foreach (var r in results)
+            {
+                Assert.IsNotNull(r.DepthCorrection, "Every date step should have depth correction");
+                Assert.AreEqual(1500, r.DepthCorrection.DepthMeters, 0.01);
+            }
+        }
+
+        [TestMethod]
+        public void Standalone_MatchesPipeline()
+        {
+            var geoMag = LoadWMM2025();
+            var options = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 2000,
+                WellboreAzimuth = 45,
+                WellboreInclination = 60
+            };
+            options.SetElevation(0, Distance.Unit.meter, true);
+
+            var pipelineResults = geoMag.MagneticCalculations(options);
+            var pipelineDC = pipelineResults[0].DepthCorrection;
+
+            // Now compute standalone using surface field (no depth in options)
+            options.SurveyDepthMeters = null;
+            var surfaceResults = geoMag.MagneticCalculations(options);
+            var standaloneDC = DepthCorrection.Calculate(surfaceResults[0], 2000,
+                wellboreAzimuthDeg: 45, wellboreInclinationDeg: 60);
+
+            Assert.AreEqual(pipelineDC.DipoleScalingFactor, standaloneDC.DipoleScalingFactor, 1e-10);
+            Assert.AreEqual(pipelineDC.HorizontalError, standaloneDC.HorizontalError, 0.01);
+            Assert.AreEqual(pipelineDC.AzimuthErrorDeg.Value, standaloneDC.AzimuthErrorDeg.Value, 0.001);
+        }
+
+        [TestMethod]
+        public void SHRecalc_vs_Dipole_Agreement()
+        {
+            // Compare: dipole correction vs. running SH model at reduced altitude
+            var geoMag = LoadWMM2025();
+
+            // Surface calculation
+            var surfaceOptions = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1)
+            };
+            surfaceOptions.SetElevation(0, Distance.Unit.meter, true);
+            var surfaceResults = geoMag.MagneticCalculations(surfaceOptions);
+            var surfaceField = surfaceResults[0];
+
+            // Dipole correction for 2km depth
+            var dipoleResult = DepthCorrection.Calculate(surfaceField, 2000);
+
+            // SH model at -2km altitude (below sea level)
+            var depthOptions = new CalculationOptions
+            {
+                Latitude = 45,
+                Longitude = 0,
+                StartDate = new DateTime(2025, 1, 1)
+            };
+            depthOptions.SetElevation(-2000, Distance.Unit.meter, true);
+            var depthResults = geoMag.MagneticCalculations(depthOptions);
+            var shField = depthResults[0];
+
+            // They should agree within ~1 nT for horizontal intensity
+            Assert.AreEqual(shField.HorizontalIntensity.Value, dipoleResult.HorizontalIntensityAtDepth, 5.0,
+                "SH and dipole should agree within 5 nT for horizontal intensity at 2km depth");
+        }
+
+        #endregion
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+git commit -m "test: add integration tests for depth correction pipeline"
+```
+
+---
+
+### Task 9: Create tasks.md and push branch
+
+**Files:**
+- Create: `docs/features/3-depth-adjusted-field/tasks.md`
+
+- [ ] **Step 1: Create tasks.md**
+
+```markdown
+# Feature: Depth-Adjusted Magnetic Field Values
+Issue: #3
+Branch: feature/3-depth-adjusted-field
+
+## Tasks
+- [x] Create DepthCorrectionResult class
+- [x] Create DepthCorrection static class with Eq 1-8
+- [x] Add tool-frame and boundary tests
+- [x] Add MagneticCalculations convenience overload
+- [x] Add SurveyDepthMeters and wellbore properties to CalculationOptions
+- [x] Add DepthCorrection property to MagneticCalculations and DepthAzimuthUncertainty
+- [x] Integrate into GeoMag sync and async pipeline
+- [x] Add integration tests with WMM2025
+- [ ] 2 clean Ralph Loop cycles
+
+## Completion Criteria
+- [ ] All tasks checked
+- [ ] Build succeeds
+- [ ] Tests pass
+- [ ] 2 clean Ralph Loop cycles
+```
+
+- [ ] **Step 2: Push branch and create draft PR**
+
+```bash
+git add docs/features/3-depth-adjusted-field/tasks.md
+git commit -m "docs: add tasks.md for Issue #3 depth-adjusted field"
+git push -u origin feature/3-depth-adjusted-field
+gh pr create --base development --draft --title "feat: add depth-adjusted magnetic field values (#3)" --body "$(cat <<'EOF'
+## Summary
+- Add dipole depth correction per SPE-128217-MS (Eq 1-8)
+- Standalone `DepthCorrection.Calculate()` API for MSA workflows
+- Pipeline-integrated: set `SurveyDepthMeters` in options
+- Depth-dependent azimuth uncertainty added to `GeomagneticUncertainty`
+- East-west singularity detection and flagging
+
+## References
+- SPE-128217-MS (Ekseth & Weston, Gyrodata, 2010)
+- Issue #3
+
+## Test plan
+- [ ] 17 unit tests for dipole math, validation, boundary cases
+- [ ] 7 integration tests with WMM2025 model
+- [ ] SH recalculation vs dipole correction agreement test
+- [ ] Ralph Loop review (2 clean cycles)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify all tests pass one final time**
+
+Run: `dotnet test -c Release --verbosity normal`
+Expected: All tests PASS, 0 failures

--- a/docs/superpowers/specs/2026-03-11-depth-adjusted-field-design.md
+++ b/docs/superpowers/specs/2026-03-11-depth-adjusted-field-design.md
@@ -1,0 +1,321 @@
+# Depth-Adjusted Magnetic Field Values & Depth-Dependent Uncertainty
+
+**Issue:** #3
+**Date:** 2026-03-11
+**Reference:** SPE-128217-MS (Ekseth & Weston, Gyrodata, 2010)
+
+## Goal
+
+Add depth-adjusted magnetic field values and depth-dependent uncertainty estimates to GeoMagSharp, enabling MWD/MSA applications to account for the systematic error introduced when using surface geomagnetic field values at downhole survey depths.
+
+## Background
+
+SPE-128217-MS demonstrates that geomagnetic field variation with depth is a significant unaccounted error source in IFR-corrected MWD surveys. Their Monte Carlo analysis (9000 runs) shows:
+
+- Global depth variation adds **0.38° (1σ) azimuth error** from this source alone
+- This is **more than double** the IFR error model prediction of 0.18°
+- The IIFR-MSC error model underestimates real wellbore position uncertainty by 50% or more
+- A horizontal east-west singularity exists in the `(1 - sin²A·sin²I)` denominator
+
+The Earth's global magnetic field strengthens with depth following an R³/(R-D)³ relationship. The paper provides analytical equations (Eq 1-8) to quantify this effect.
+
+## Scope
+
+**In scope:**
+- Phase 1: Dipole depth correction (SPE-128217 Eq 1-8)
+- Phase 2: Depth-dependent uncertainty integrated into existing uncertainty class
+- Both pipeline-integrated and standalone API
+- East-west singularity detection and flagging
+- Validation test comparing dipole correction against SH recalculation at reduced altitude (not a separate API — consumers can already call the existing pipeline with negative altitude for SH-based depth values)
+
+**Out of scope (deferred):**
+- Crustal anomaly amplification modeling (SPE-128217 Section "Crustal anomalies")
+- Downward continuation algorithms
+- Level 2/3 location-dependent uncertainty (requires BGS lookup tables)
+
+## Architecture
+
+### Approach: Post-Processing Layer
+
+Compute the standard surface field first (existing pipeline unchanged), then apply depth corrections as a post-processing step. A new public static class `DepthCorrection` handles all the math.
+
+**Rationale:** The paper's contribution is quantifying the *error introduced by using surface values at depth* — not computing an alternative SH field underground. The post-processing approach directly implements the paper's equations and keeps the existing pipeline untouched.
+
+### Depth Coordinate Model
+
+```
+                Sea level
+                ─────────────
+                     |
+                     | Surface elevation (existing: SetElevation)
+                     |
+Rig floor ──────────►┌─────┐
+                     │     │
+                     │  ↓  │  SurveyDepthMeters (new: always positive, downward)
+                     │     │
+Survey station ─────►└─────┘
+```
+
+- **Elevation/Altitude** → where the surface calculation happens (existing API, unchanged)
+- **SurveyDepthMeters** → how far below that surface the survey tool is (new, always positive)
+
+These are independent. To model locations above the surface, increase the altitude — no negative depth needed.
+
+### Geomagnetic Latitude
+
+Derived self-consistently from the computed field: `φ = atan(B_v / (2·B_h))` where `B_v` is the vertical component (Z, positive downward in GeoMagSharp's `VerticalComp`) and `B_h` is the horizontal intensity (`HorizontalIntensity`). Use `Math.Atan2(Bv, 2*Bh)` to handle all quadrants correctly. When `B_h ≈ 0` (magnetic pole), use `φ = 90°` directly.
+
+### Equatorial Dipole Field Strength (B₀)
+
+In Eq 1-8, `B` represents the **equatorial dipole field strength** (B₀), NOT the total measured field. It is derived from the surface field components:
+
+```
+B₀ = B_h / cos(φ)     (equivalently: B₀ = B_v / (2·sin(φ)))
+```
+
+This ensures self-consistency: `B₀·cos(φ) = B_h` and `2·B₀·sin(φ) = B_v`.
+
+## Equations (SPE-128217)
+
+### Field at depth (Eq 1-2)
+
+```
+B_h(D) = B₀·cos(φ) · R³/(R-D)³     (horizontal component)
+B_v(D) = 2·B₀·sin(φ) · R³/(R-D)³   (vertical component)
+F(D)   = √(B_h(D)² + B_v(D)²)      (total field at depth)
+```
+
+### Error from using surface values (Eq 3-4)
+
+**Note:** These are first-order Taylor approximations of Eq 1-2, valid when D << R. At D = 4 km and R = 6371 km, D/R ≈ 0.0006, so the approximation error is negligible (< 0.001%).
+
+```
+ΔB_h = 3·B₀·cos(φ) · D/R
+ΔB_v = 6·B₀·sin(φ) · D/R
+```
+
+### Tool-frame error components (Eq 5-7)
+
+Requires wellbore **magnetic** azimuth (A, relative to magnetic north) and inclination (I). If the consumer has true azimuth, they must subtract the declination first.
+
+```
+ΔB_H =  3·B₀·(cos(φ)·cos(A)·cos(I) - 2·sin(φ)·sin(I)) · D/R   (high-side)
+ΔB_R = -3·B₀·cos(φ)·sin(A) · D/R                                  (high-side-right)
+ΔB_A =  3·B₀·(cos(φ)·cos(A)·sin(I) + 2·sin(φ)·cos(I)) · D/R    (along-hole)
+```
+
+### Azimuth error approximation (Eq 8)
+
+```
+ΔA ≈ (sin(2A)·sin²(I) + 2·tan(φ)·sin(A)·sin(2I)) · 1.5·D/R
+     ─────────────────────────────────────────────────────────
+                    (1 - sin²(A)·sin²(I))
+```
+
+Where `sin(2A)` and `sin(2I)` are double-angle functions: `sin(2A) = 2·sin(A)·cos(A)`.
+
+The denominator `(1 - sin²(A)·sin²(I))` creates a singularity for east-west wells at high inclination.
+
+### Worked Example
+
+**Location:** B_h = 20000 nT, B_v = 40000 nT (typical mid-latitude)
+**Depth:** D = 3000 m, **Wellbore:** A = 45°, I = 60°
+
+1. Geomagnetic latitude: `φ = atan(40000 / (2·20000)) = atan(1.0) = 45.0°`
+2. Equatorial field: `B₀ = 20000 / cos(45°) = 28284.3 nT`
+3. Verify: `2·28284.3·sin(45°) = 40000 nT ✓`
+4. Scaling factor: `R³/(R-D)³ = 6371000³/6368000³ = 1.001413`
+5. B_h at depth: `28284.3·cos(45°)·1.001413 = 20028.3 nT` (ΔB_h = +28.3 nT)
+6. B_v at depth: `2·28284.3·sin(45°)·1.001413 = 40056.5 nT` (ΔB_v = +56.5 nT)
+7. Linear approx (Eq 3): `3·28284.3·cos(45°)·3000/6371000 = 28.2 nT ✓` (agrees to 0.1 nT)
+8. Linear approx (Eq 4): `6·28284.3·sin(45°)·3000/6371000 = 56.5 nT ✓`
+9. Singularity factor: `1 - sin²(45°)·sin²(60°) = 1 - 0.5·0.75 = 0.625` (safe)
+10. Azimuth error (Eq 8): `(sin(90°)·0.75 + 2·tan(45°)·sin(45°)·sin(120°)) · 1.5·3000/6371000 / 0.625`
+    = `(0.75 + 2·1.0·0.7071·0.8660) · 0.000707 / 0.625`
+    = `(0.75 + 1.2247) · 0.000707 / 0.625`
+    = `1.9747 · 0.001131 = 0.00223 rad = 0.128°`
+
+## File Structure
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/GeoMagSharp/DepthCorrection.cs` | Public static class with all depth math (Eq 1-8) |
+| `src/GeoMagSharp/Models/Results/DepthCorrectionResult.cs` | Result class for depth corrections |
+| `tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs` | Unit and integration tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/GeoMagSharp/Models/Configuration/CalculationOptions.cs` | Add `SurveyDepthMeters`, `WellboreAzimuth`, `WellboreInclination` + update copy constructor |
+| `src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs` | Add `DepthAzimuthUncertainty` field |
+| `src/GeoMagSharp/Models/Results/MagneticCalculations.cs` | Add `DepthCorrection` property + update copy constructor |
+| `src/GeoMagSharp/GeoMag.cs` | Integrate depth correction into sync + async pipeline |
+
+## API Design
+
+### Input — CalculationOptions Additions
+
+```csharp
+public double? SurveyDepthMeters { get; set; }      // TVD below surface, always positive
+public double? WellboreAzimuth { get; set; }         // magnetic azimuth in degrees (0-360), optional
+public double? WellboreInclination { get; set; }     // degrees (0-180), optional
+```
+
+**Azimuth convention:** `WellboreAzimuth` is **magnetic azimuth** (relative to magnetic north), consistent with MWD tool output and SPE-128217 equations. If the consumer has true (geographic) azimuth, they must subtract the declination before passing it here.
+
+**Inclination convention:** Standard MWD convention: 0° = vertical, 90° = horizontal, >90° = past-horizontal. The full 0-180° range is supported.
+
+**Copy constructor:** All three properties must be copied in `CalculationOptions(CalculationOptions other)`. Without this, the pipeline-integrated mode will silently drop depth parameters since `GeoMag.cs` copies options at line ~131.
+
+When `SurveyDepthMeters` has a value, the pipeline auto-computes depth correction. Wellbore geometry is optional — when absent, Eq 5-8 (tool-frame and azimuth error) are skipped.
+
+### Standalone API — DepthCorrection
+
+```csharp
+public static class DepthCorrection
+{
+    /// Calculate depth correction from surface field values.
+    /// Uses dipole approximation (SPE-128217 Eq 1-8).
+    public static DepthCorrectionResult Calculate(
+        double horizontalIntensityNT,
+        double verticalIntensityNT,
+        double totalFieldNT,
+        double depthMeters,
+        double? wellboreAzimuthDeg = null,
+        double? wellboreInclinationDeg = null,
+        double earthRadiusKm = Constants.EarthsRadiusInKm);
+
+    /// Convenience overload accepting MagneticCalculations directly.
+    public static DepthCorrectionResult Calculate(
+        MagneticCalculations surfaceField,
+        double depthMeters,
+        double? wellboreAzimuthDeg = null,
+        double? wellboreInclinationDeg = null);
+}
+```
+
+The `totalFieldNT` parameter is used to compute `TotalFieldAtDepth` via `F(D) = F · R³/(R-D)³`. In a pure dipole, B_h and B_v scale identically, so total field scales by the same factor. This is mathematically equivalent to `√(B_h(D)² + B_v(D)²)` but avoids floating-point error accumulation.
+
+Three usage modes:
+1. **Pipeline-integrated** — set `SurveyDepthMeters` in options, get corrections automatically
+2. **Standalone with GeoMagSharp field** — compute surface field first, then call `DepthCorrection.Calculate()` with `MagneticCalculations`
+3. **Standalone with external field** — provide B_h, B_v, F values from any source
+
+### Output — DepthCorrectionResult
+
+```csharp
+public class DepthCorrectionResult
+{
+    // Dipole scaling factor: R³/(R-D)³
+    public double DipoleScalingFactor { get; set; }
+
+    // Corrected field components at depth (Eq 1-2)
+    public double HorizontalIntensityAtDepth { get; set; }  // nT
+    public double VerticalIntensityAtDepth { get; set; }     // nT
+    public double TotalFieldAtDepth { get; set; }            // nT
+
+    // Field errors from using surface values (Eq 3-4)
+    public double HorizontalError { get; set; }   // ΔB_h in nT
+    public double VerticalError { get; set; }      // ΔB_v in nT
+
+    // Tool-frame error components (Eq 5-7) — null when no wellbore geometry
+    public double? HighSideError { get; set; }      // ΔB_H in nT
+    public double? HighSideRightError { get; set; } // ΔB_R in nT
+    public double? AlongHoleError { get; set; }     // ΔB_A in nT
+
+    // Azimuth error estimate (Eq 8) — null when no wellbore geometry
+    public double? AzimuthErrorDeg { get; set; }    // ΔA in degrees
+
+    // Singularity proximity: (1 - sin²A·sin²I), values near 0 = singularity
+    public double? SingularityFactor { get; set; }
+    public bool? NearSingularity { get; set; }      // true if factor < 0.1
+
+    // Geomagnetic latitude derived from field: atan(Bv / 2Bh)
+    public double GeomagneticLatitudeDeg { get; set; }
+
+    // Metadata
+    public double DepthMeters { get; set; }
+    public string Reference { get; set; }  // "SPE-128217-MS"
+}
+```
+
+### Uncertainty Extension
+
+Added to existing `GeomagneticUncertainty` class:
+
+```csharp
+public double? DepthAzimuthUncertainty { get; set; }  // degrees, 1σ
+```
+
+- When wellbore geometry provided: computed from Eq 8
+- When not provided: 0.38° global average from Monte Carlo (SPE-128217 p.8)
+- Only populated when `SurveyDepthMeters` is specified
+
+### Pipeline Integration
+
+Added to `MagneticCalculations`:
+
+```csharp
+public DepthCorrectionResult DepthCorrection { get; set; }  // null when no depth specified
+```
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| `depthMeters < 0` | `ArgumentOutOfRangeException` |
+| `depthMeters = 0` | Allowed — returns identity scaling (factor = 1.0, zero errors) |
+| `depthMeters > 10000` | Allowed (math valid, dipole approximation degrades gradually) |
+| `wellboreInclination` outside 0-180° | `ArgumentOutOfRangeException` |
+| `wellboreAzimuth` outside 0-360° | Normalize (mod 360) |
+| `horizontalIntensityNT ≈ 0` | Use geomagnetic latitude = 90° (magnetic pole) |
+| `earthRadiusKm ≤ 0` | `ArgumentOutOfRangeException` |
+| Singularity factor < 0.1 | `NearSingularity = true`, Eq 8 still computed but flagged |
+| `SurveyDepthMeters = null` | No depth correction, `DepthCorrection` property stays null |
+
+## Testing Strategy
+
+### Unit Tests (pure math, no model loading)
+
+| Test | Validates |
+|------|-----------|
+| `DipoleScaling_ZeroDepth_ReturnsOne` | Edge case: no correction at surface |
+| `DipoleScaling_1km_CorrectFactor` | R³/(R-D)³ ≈ 1.000471 at 1 km |
+| `HorizontalError_Eq3_MatchesPaper` | ΔB_h = 3B·cos(φ)·D/R |
+| `VerticalError_Eq4_MatchesPaper` | ΔB_v = 6B·sin(φ)·D/R |
+| `ToolFrameErrors_Eq567_MatchesPaper` | High-side, right, along-hole components |
+| `AzimuthError_Eq8_KnownCase` | Validate against paper's Figure 2/3 examples |
+| `AzimuthError_NearSingularity_Flagged` | A≈90°, I≈85° → NearSingularity=true |
+| `GeomagneticLatitude_DerivedFromField` | tan(φ) = Bv/(2·Bh) roundtrip |
+| `NullWellboreGeometry_SkipsEq8` | Tool-frame and azimuth error are null |
+| `TotalFieldAtDepth_DerivedFromComponents` | F(D) = √(B_h(D)² + B_v(D)²) |
+| `NegativeDepth_ThrowsException` | Input validation |
+| `ZeroDepth_ReturnsIdentity` | All errors are zero, scaling factor = 1.0 |
+| `ZeroHorizontalIntensity_MagneticPole` | φ = 90°, no division by zero |
+| `VerticalWell_ToolFrameErrors` | I = 0° degenerates correctly |
+| `NorthAzimuth_ToolFrameErrors` | A = 0° boundary case |
+| `ZeroEarthRadius_ThrowsException` | Input validation |
+| `ConvenienceOverload_MatchesPrimitive` | MagneticCalculations overload extracts correct values |
+
+### Integration Tests (with WMM2025 model)
+
+| Test | Validates |
+|------|-----------|
+| `Pipeline_WithDepth_PopulatesCorrection` | End-to-end: set SurveyDepthMeters, check result |
+| `Pipeline_WithoutDepth_NullCorrection` | Backward compatibility |
+| `Pipeline_WithWellboreGeometry_HasAzimuthError` | Full Eq 8 path |
+| `Standalone_MatchesPipeline` | Standalone API gives same results as pipeline |
+| `DepthUncertainty_AddedToUncertainty` | DepthAzimuthUncertainty populated |
+| `DateRange_AllStepsGetDepthCorrection` | Multi-step calculation |
+| `SHRecalc_vs_Dipole_Agreement` | SH at reduced altitude agrees with dipole correction within ~1 nT |
+
+## Limitations
+
+1. **Crustal anomaly amplification not modeled.** The dipole correction handles global field variation only. Crustal anomalies (200-1000 nT typical) intensify non-linearly with depth and are location-specific. This is noted in SPE-128217 Section "Crustal anomalies" and deferred to a future issue.
+
+2. **Dipole approximation.** The depth correction uses a dipole model, which captures ~90% of the global field. Higher-order terms (quadrupole, octupole) are negligible at typical drilling depths (0-4 km) relative to Earth's radius (6371 km).
+
+3. **East-west singularity.** Eq 8 becomes unreliable near the horizontal east-west direction. The `NearSingularity` flag alerts consumers but cannot eliminate the mathematical limitation.

--- a/src/GeoMagSharp/DepthCorrection.cs
+++ b/src/GeoMagSharp/DepthCorrection.cs
@@ -1,0 +1,163 @@
+/****************************************************************************
+ * File:            DepthCorrection.cs
+ * Description:     Dipole depth correction per SPE-128217-MS
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ * Notes:           Reference: SPE-128217-MS (Ekseth & Weston, Gyrodata, 2010)
+ *                  "Wellbore Positions Obtained While Drilling by the Most
+ *                  Advanced Magnetic Surveying Methods May Be Less Accurate
+ *                  than Predicted"
+ ****************************************************************************/
+
+using System;
+
+namespace GeoMagSharp
+{
+    /// <summary>
+    /// Calculates dipole depth corrections for geomagnetic field values
+    /// per SPE-128217-MS (Ekseth &amp; Weston, 2010).
+    /// </summary>
+    public static class DepthCorrection
+    {
+        private const double SingularityThreshold = 0.1;
+        private const double HorizontalIntensityPoleThreshold = 1.0; // nT
+        private const double DegToRad = Math.PI / 180.0;
+        private const double RadToDeg = 180.0 / Math.PI;
+
+        /// <summary>
+        /// Calculate depth correction from surface field values using dipole approximation.
+        /// </summary>
+        /// <param name="horizontalIntensityNT">Surface horizontal intensity B_h (nT)</param>
+        /// <param name="verticalIntensityNT">Surface vertical intensity B_v (nT, positive downward)</param>
+        /// <param name="totalFieldNT">Surface total field F (nT)</param>
+        /// <param name="depthMeters">Survey depth below surface (meters, must be >= 0)</param>
+        /// <param name="wellboreAzimuthDeg">Magnetic azimuth (degrees, 0-360). Null to skip Eq 5-8.</param>
+        /// <param name="wellboreInclinationDeg">Wellbore inclination (degrees, 0-180). Null to skip Eq 5-8.</param>
+        /// <param name="earthRadiusKm">Earth radius (km). Default: Constants.EarthsRadiusInKm</param>
+        public static DepthCorrectionResult Calculate(
+            double horizontalIntensityNT,
+            double verticalIntensityNT,
+            double totalFieldNT,
+            double depthMeters,
+            double? wellboreAzimuthDeg = null,
+            double? wellboreInclinationDeg = null,
+            double earthRadiusKm = Constants.EarthsRadiusInKm)
+        {
+            if (depthMeters < 0)
+                throw new ArgumentOutOfRangeException(nameof(depthMeters), "Depth must be >= 0");
+            if (earthRadiusKm <= 0)
+                throw new ArgumentOutOfRangeException(nameof(earthRadiusKm), "Earth radius must be > 0");
+            if (wellboreInclinationDeg.HasValue && (wellboreInclinationDeg.Value < 0 || wellboreInclinationDeg.Value > 180))
+                throw new ArgumentOutOfRangeException(nameof(wellboreInclinationDeg), "Inclination must be 0-180 degrees");
+
+            double earthRadiusM = earthRadiusKm * 1000.0;
+
+            // Geomagnetic latitude: φ = atan(Bv / (2·Bh))
+            double geomagLatRad;
+            if (Math.Abs(horizontalIntensityNT) < HorizontalIntensityPoleThreshold)
+            {
+                geomagLatRad = Math.PI / 2.0; // 90° at magnetic pole
+            }
+            else
+            {
+                geomagLatRad = Math.Atan2(verticalIntensityNT, 2.0 * horizontalIntensityNT);
+            }
+
+            double cosPhi = Math.Cos(geomagLatRad);
+            double sinPhi = Math.Sin(geomagLatRad);
+
+            // Equatorial dipole field: B₀ = Bh / cos(φ)
+            double B0 = Math.Abs(cosPhi) > 1e-10
+                ? horizontalIntensityNT / cosPhi
+                : verticalIntensityNT / (2.0 * sinPhi);
+
+            // Dipole scaling factor: R³/(R-D)³
+            double scalingFactor = Math.Pow(earthRadiusM / (earthRadiusM - depthMeters), 3);
+
+            // Field at depth (Eq 1-2)
+            double bhAtDepth = horizontalIntensityNT * scalingFactor;
+            double bvAtDepth = verticalIntensityNT * scalingFactor;
+            double fAtDepth = totalFieldNT * scalingFactor;
+
+            // Field errors (Eq 3-4): first-order approximation
+            double dOverR = depthMeters / earthRadiusM;
+            double deltaH = 3.0 * B0 * cosPhi * dOverR;
+            double deltaV = 6.0 * B0 * sinPhi * dOverR;
+
+            var result = new DepthCorrectionResult
+            {
+                DipoleScalingFactor = scalingFactor,
+                HorizontalIntensityAtDepth = bhAtDepth,
+                VerticalIntensityAtDepth = bvAtDepth,
+                TotalFieldAtDepth = fAtDepth,
+                HorizontalError = deltaH,
+                VerticalError = deltaV,
+                GeomagneticLatitudeDeg = geomagLatRad * RadToDeg,
+                DepthMeters = depthMeters,
+                Reference = "SPE-128217-MS"
+            };
+
+            // Tool-frame errors and azimuth error (Eq 5-8) — requires wellbore geometry
+            if (wellboreAzimuthDeg.HasValue && wellboreInclinationDeg.HasValue)
+            {
+                double A = (wellboreAzimuthDeg.Value % 360.0) * DegToRad;
+                double I = wellboreInclinationDeg.Value * DegToRad;
+
+                double cosA = Math.Cos(A);
+                double sinA = Math.Sin(A);
+                double cosI = Math.Cos(I);
+                double sinI = Math.Sin(I);
+
+                // Eq 5: ΔB_H (high-side)
+                result.HighSideError = 3.0 * B0 * (cosPhi * cosA * cosI - 2.0 * sinPhi * sinI) * dOverR;
+
+                // Eq 6: ΔB_R (high-side-right)
+                result.HighSideRightError = -3.0 * B0 * cosPhi * sinA * dOverR;
+
+                // Eq 7: ΔB_A (along-hole)
+                result.AlongHoleError = 3.0 * B0 * (cosPhi * cosA * sinI + 2.0 * sinPhi * cosI) * dOverR;
+
+                // Singularity factor: (1 - sin²A·sin²I)
+                double singFactor = 1.0 - sinA * sinA * sinI * sinI;
+                result.SingularityFactor = singFactor;
+                result.NearSingularity = singFactor < SingularityThreshold;
+
+                // Eq 8: ΔA (azimuth error)
+                double sin2A = Math.Sin(2.0 * A);
+                double sin2I = Math.Sin(2.0 * I);
+                double tanPhi = Math.Abs(cosPhi) > 1e-10 ? sinPhi / cosPhi : 1e10;
+
+                double numerator = (sin2A * sinI * sinI + 2.0 * tanPhi * sinA * sin2I) * 1.5 * dOverR;
+                double azErrorRad = Math.Abs(singFactor) > 1e-10
+                    ? numerator / singFactor
+                    : numerator / 1e-10; // Avoid division by zero
+
+                result.AzimuthErrorDeg = azErrorRad * RadToDeg;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Convenience overload accepting MagneticCalculations directly.
+        /// Extracts HorizontalIntensity, VerticalComp, and TotalField values.
+        /// </summary>
+        public static DepthCorrectionResult Calculate(
+            MagneticCalculations surfaceField,
+            double depthMeters,
+            double? wellboreAzimuthDeg = null,
+            double? wellboreInclinationDeg = null)
+        {
+            if (surfaceField == null)
+                throw new ArgumentNullException(nameof(surfaceField));
+
+            return Calculate(
+                surfaceField.HorizontalIntensity.Value,
+                surfaceField.VerticalComp.Value,
+                surfaceField.TotalField.Value,
+                depthMeters,
+                wellboreAzimuthDeg,
+                wellboreInclinationDeg);
+        }
+    }
+}

--- a/src/GeoMagSharp/DepthCorrection.cs
+++ b/src/GeoMagSharp/DepthCorrection.cs
@@ -25,6 +25,12 @@ namespace GeoMagSharp
         private const double RadToDeg = 180.0 / Math.PI;
 
         /// <summary>
+        /// Depth-dependent azimuth uncertainty (degrees, 1-sigma) from SPE-128217-MS Monte Carlo analysis.
+        /// Global average σ_ΔA ≈ 0.38° for depths up to 4 km.
+        /// </summary>
+        public const double DepthAzimuthUncertaintyDeg = 0.38;
+
+        /// <summary>
         /// Calculate depth correction from surface field values using dipole approximation.
         /// </summary>
         /// <param name="horizontalIntensityNT">Surface horizontal intensity B_h (nT)</param>

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -511,7 +511,7 @@ namespace GeoMagSharp
                     TotalField = magCalc.Uncertainty.TotalField,
                     DipAngle = magCalc.Uncertainty.DipAngle,
                     Revision = magCalc.Uncertainty.Revision,
-                    DepthAzimuthUncertainty = 0.38
+                    DepthAzimuthUncertainty = DepthCorrection.DepthAzimuthUncertaintyDeg
                 };
             }
         }

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -149,6 +149,7 @@ namespace GeoMagSharp
                 if (magCalcDate != null)
                 {
                     magCalcDate.Uncertainty = uncertainty;
+                    ApplyDepthCorrection(magCalcDate, _CalculationOptions);
                     ResultsOfCalculation.Add(magCalcDate);
                 }
 
@@ -364,6 +365,7 @@ namespace GeoMagSharp
                 if (magCalcDate != null)
                 {
                     magCalcDate.Uncertainty = uncertainty;
+                    ApplyDepthCorrection(magCalcDate, _CalculationOptions);
                     ResultsOfCalculation.Add(magCalcDate);
                 }
 
@@ -483,6 +485,35 @@ namespace GeoMagSharp
 
                 File.WriteAllText(fileName, content);
             }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Applies dipole depth correction to a calculation result if SurveyDepthMeters is set.
+        /// </summary>
+        private static void ApplyDepthCorrection(MagneticCalculations magCalc, CalculationOptions options)
+        {
+            if (!options.SurveyDepthMeters.HasValue)
+                return;
+
+            magCalc.DepthCorrection = DepthCorrection.Calculate(
+                magCalc,
+                options.SurveyDepthMeters.Value,
+                options.WellboreAzimuthDeg,
+                options.WellboreInclinationDeg);
+
+            if (magCalc.Uncertainty != null)
+            {
+                magCalc.Uncertainty = new GeomagneticUncertainty
+                {
+                    ModelCategory = magCalc.Uncertainty.ModelCategory,
+                    Declination = magCalc.Uncertainty.Declination,
+                    BhDependentDec = magCalc.Uncertainty.BhDependentDec,
+                    TotalField = magCalc.Uncertainty.TotalField,
+                    DipAngle = magCalc.Uncertainty.DipAngle,
+                    Revision = magCalc.Uncertainty.Revision,
+                    DepthAzimuthUncertainty = 0.38
+                };
+            }
         }
 
     }

--- a/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
+++ b/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
@@ -34,6 +34,10 @@ namespace GeoMagSharp
             ElevationValue = 0;
             ElevationUnit = Distance.Unit.meter;
             ElevationIsAltitude = true;
+
+            SurveyDepthMeters = null;
+            WellboreAzimuthDeg = null;
+            WellboreInclinationDeg = null;
         }
 
         /// <summary>
@@ -54,6 +58,10 @@ namespace GeoMagSharp
             ElevationValue = other.ElevationValue;
             ElevationUnit = other.ElevationUnit;
             ElevationIsAltitude = other.ElevationIsAltitude;
+
+            SurveyDepthMeters = other.SurveyDepthMeters;
+            WellboreAzimuthDeg = other.WellboreAzimuthDeg;
+            WellboreInclinationDeg = other.WellboreInclinationDeg;
         }
 
         #endregion
@@ -85,6 +93,22 @@ namespace GeoMagSharp
         /// Set this for commercial models (BGGM, HDGM) or IFR corrections.
         /// </summary>
         public GeomagneticModelCategory? ModelCategoryOverride { get; set; }
+
+        /// <summary>
+        /// Survey depth below surface (meters, positive downward). Null to skip depth correction.
+        /// Used for dipole depth correction per SPE-128217-MS.
+        /// </summary>
+        public double? SurveyDepthMeters { get; set; }
+
+        /// <summary>
+        /// Wellbore magnetic azimuth (degrees, 0-360). Null to skip tool-frame error calculations (Eq 5-8).
+        /// </summary>
+        public double? WellboreAzimuthDeg { get; set; }
+
+        /// <summary>
+        /// Wellbore inclination (degrees, 0-180). Null to skip tool-frame error calculations (Eq 5-8).
+        /// </summary>
+        public double? WellboreInclinationDeg { get; set; }
 
         #region Getters & Setters
 

--- a/src/GeoMagSharp/Models/Results/DepthCorrectionResult.cs
+++ b/src/GeoMagSharp/Models/Results/DepthCorrectionResult.cs
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * File:            DepthCorrectionResult.cs
+ * Description:     Result class for dipole depth correction (SPE-128217-MS)
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ ****************************************************************************/
+
+namespace GeoMagSharp
+{
+    /// <summary>
+    /// Results of dipole depth correction per SPE-128217-MS (Ekseth &amp; Weston, 2010).
+    /// Null tool-frame and azimuth error properties indicate wellbore geometry was not provided.
+    /// </summary>
+    public class DepthCorrectionResult
+    {
+        /// <summary>Dipole scaling factor: R³/(R-D)³</summary>
+        public double DipoleScalingFactor { get; set; }
+
+        /// <summary>Horizontal intensity at depth (nT), Eq 1</summary>
+        public double HorizontalIntensityAtDepth { get; set; }
+
+        /// <summary>Vertical intensity at depth (nT), Eq 2</summary>
+        public double VerticalIntensityAtDepth { get; set; }
+
+        /// <summary>Total field at depth (nT), derived from Eq 1-2</summary>
+        public double TotalFieldAtDepth { get; set; }
+
+        /// <summary>Horizontal field error from using surface values (nT), Eq 3</summary>
+        public double HorizontalError { get; set; }
+
+        /// <summary>Vertical field error from using surface values (nT), Eq 4</summary>
+        public double VerticalError { get; set; }
+
+        /// <summary>High-side error component (nT), Eq 5. Null if no wellbore geometry.</summary>
+        public double? HighSideError { get; set; }
+
+        /// <summary>High-side-right error component (nT), Eq 6. Null if no wellbore geometry.</summary>
+        public double? HighSideRightError { get; set; }
+
+        /// <summary>Along-hole error component (nT), Eq 7. Null if no wellbore geometry.</summary>
+        public double? AlongHoleError { get; set; }
+
+        /// <summary>Azimuth error estimate (degrees), Eq 8. Null if no wellbore geometry.</summary>
+        public double? AzimuthErrorDeg { get; set; }
+
+        /// <summary>Singularity proximity: (1 - sin²A·sin²I). Values near 0 indicate E-W singularity.</summary>
+        public double? SingularityFactor { get; set; }
+
+        /// <summary>True when SingularityFactor &lt; 0.1, indicating Eq 8 is unreliable.</summary>
+        public bool? NearSingularity { get; set; }
+
+        /// <summary>Geomagnetic latitude (degrees), derived from field: atan(Bv / 2Bh)</summary>
+        public double GeomagneticLatitudeDeg { get; set; }
+
+        /// <summary>Survey depth below surface (meters)</summary>
+        public double DepthMeters { get; set; }
+
+        /// <summary>Reference paper identifier</summary>
+        public string Reference { get; set; }
+    }
+}

--- a/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
+++ b/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
@@ -38,6 +38,13 @@ namespace GeoMagSharp
         public string Revision { get; set; }
 
         /// <summary>
+        /// Depth-dependent azimuth uncertainty in degrees, 1-sigma.
+        /// From SPE-128217-MS Monte Carlo analysis: σ_ΔA ≈ 0.38° global average.
+        /// Null if depth correction was not applied.
+        /// </summary>
+        public double? DepthAzimuthUncertainty { get; set; }
+
+        /// <summary>
         /// Returns a new instance with all uncertainty values multiplied by the given scale factor.
         /// Note: This is a linear approximation. Geomagnetic errors follow a Laplacian
         /// (non-Gaussian) distribution, so scaled values are approximate at levels other than 1-sigma.
@@ -52,7 +59,10 @@ namespace GeoMagSharp
                 BhDependentDec = BhDependentDec * scaleFactor,
                 TotalField = TotalField * scaleFactor,
                 DipAngle = DipAngle * scaleFactor,
-                Revision = Revision
+                Revision = Revision,
+                DepthAzimuthUncertainty = DepthAzimuthUncertainty.HasValue
+                    ? DepthAzimuthUncertainty.Value * scaleFactor
+                    : (double?)null
             };
         }
     }

--- a/src/GeoMagSharp/Models/Results/MagneticCalculations.cs
+++ b/src/GeoMagSharp/Models/Results/MagneticCalculations.cs
@@ -30,6 +30,7 @@ namespace GeoMagSharp
             VerticalComp = new MagneticValue();
             TotalField = new MagneticValue();
             Uncertainty = null;
+            DepthCorrection = null;
         }
 
         /// <summary>
@@ -47,6 +48,7 @@ namespace GeoMagSharp
             VerticalComp = new MagneticValue(other.VerticalComp);
             TotalField = new MagneticValue(other.TotalField);
             Uncertainty = other.Uncertainty; // Reference copy — uncertainty is immutable per calculation
+            DepthCorrection = other.DepthCorrection; // Reference copy — immutable per calculation
         }
 
         /// <summary>
@@ -151,6 +153,12 @@ namespace GeoMagSharp
         /// Null if model category is Unknown and no override was provided.
         /// </summary>
         public GeomagneticUncertainty Uncertainty { get; set; }
+
+        /// <summary>
+        /// Dipole depth correction results per SPE-128217-MS.
+        /// Null if no survey depth was provided in CalculationOptions.
+        /// </summary>
+        public DepthCorrectionResult DepthCorrection { get; set; }
 
         #endregion
     }

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -6,6 +6,8 @@
  ****************************************************************************/
 
 using System;
+using System.IO;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using GeoMagSharp;
 
@@ -352,6 +354,211 @@ namespace GeoMagSharp_UnitTests
             var unc = new GeomagneticUncertainty { DepthAzimuthUncertainty = null };
             var scaled = unc.ScaleTo(2.0);
             Assert.IsNull(scaled.DepthAzimuthUncertainty);
+        }
+
+        #endregion
+
+        #region Integration Tests (Pipeline)
+
+        private static string FindWMM2025Path()
+        {
+            var possiblePaths = new[]
+            {
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestData"),
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "TestData"),
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "tests", "GeoMagSharp.Tests", "TestData"),
+                @"C:\GitHub\GeoMagSharp\tests\GeoMagSharp.Tests\TestData"
+            };
+
+            foreach (var path in possiblePaths)
+            {
+                var candidate = Path.GetFullPath(Path.Combine(path, "WMM2025.COF"));
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+            return null;
+        }
+
+        [TestMethod]
+        public void Integration_WithDepth_HasDepthCorrection()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 3000.0
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.DepthCorrection);
+            Assert.AreEqual(3000.0, result.DepthCorrection.DepthMeters);
+            Assert.IsTrue(result.DepthCorrection.DipoleScalingFactor > 1.0);
+            Assert.AreEqual("SPE-128217-MS", result.DepthCorrection.Reference);
+        }
+
+        [TestMethod]
+        public void Integration_WithoutDepth_NoDepthCorrection()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1)
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNull(result.DepthCorrection);
+        }
+
+        [TestMethod]
+        public void Integration_WithDepthAndWellbore_HasToolFrameErrors()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 3000.0,
+                WellboreAzimuthDeg = 45.0,
+                WellboreInclinationDeg = 60.0
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.DepthCorrection);
+            Assert.IsNotNull(result.DepthCorrection.HighSideError);
+            Assert.IsNotNull(result.DepthCorrection.AzimuthErrorDeg);
+            Assert.IsNotNull(result.DepthCorrection.SingularityFactor);
+        }
+
+        [TestMethod]
+        public void Integration_WithDepth_SetsDepthAzimuthUncertainty()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 3000.0
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.Uncertainty);
+            Assert.AreEqual(0.38, result.Uncertainty.DepthAzimuthUncertainty.Value, 0.001);
+        }
+
+        [TestMethod]
+        public void Integration_WithoutDepth_NoDepthAzimuthUncertainty()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1)
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.Uncertainty);
+            Assert.IsNull(result.Uncertainty.DepthAzimuthUncertainty);
+        }
+
+        [TestMethod]
+        public void Integration_DateRange_AllResultsHaveDepthCorrection()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1),
+                EndDate = new DateTime(2025, 3, 1),
+                StepInterval = 30,
+                SurveyDepthMeters = 2000.0
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            Assert.IsTrue(geoMag.ResultsOfCalculation.Count > 1);
+            Assert.IsTrue(geoMag.ResultsOfCalculation.All(r => r.DepthCorrection != null));
+            Assert.IsTrue(geoMag.ResultsOfCalculation.All(r =>
+                r.DepthCorrection.DepthMeters == 2000.0));
+        }
+
+        [TestMethod]
+        public void Integration_FieldAtDepth_GreaterThanSurface()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null) Assert.Inconclusive("WMM2025.COF not found");
+
+            var geoMag = new GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new DateTime(2025, 1, 1),
+                SurveyDepthMeters = 3000.0
+            };
+            options.SetElevation(0, Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            // Field at depth should be stronger than surface field
+            Assert.IsTrue(result.DepthCorrection.TotalFieldAtDepth > result.TotalField.Value);
+            Assert.IsTrue(result.DepthCorrection.HorizontalIntensityAtDepth > result.HorizontalIntensity.Value);
         }
 
         #endregion

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -1,0 +1,280 @@
+/****************************************************************************
+ * File:            DepthCorrectionUnitTest.cs
+ * Description:     Tests for dipole depth correction (SPE-128217-MS)
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ ****************************************************************************/
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using GeoMagSharp;
+
+namespace GeoMagSharp_UnitTests
+{
+    [TestClass]
+    public class DepthCorrectionUnitTest
+    {
+        // Worked example from spec: B_h=20000, B_v=40000, D=3000m, A=45°, I=60°
+        private const double Bh = 20000.0;
+        private const double Bv = 40000.0;
+        private const double F = 44721.36; // sqrt(20000² + 40000²)
+        private const double DepthM = 3000.0;
+        private const double Azimuth = 45.0;
+        private const double Inclination = 60.0;
+
+        #region Input Validation
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_NegativeDepth_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, -100);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_ZeroEarthRadius_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, DepthM, earthRadiusKm: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_InclinationOutOfRange_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, DepthM, wellboreAzimuthDeg: 45, wellboreInclinationDeg: 200);
+        }
+
+        #endregion
+
+        #region Dipole Scaling and Field at Depth
+
+        [TestMethod]
+        public void Calculate_ZeroDepth_ReturnsIdentity()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, 0);
+
+            Assert.AreEqual(1.0, result.DipoleScalingFactor, 1e-10);
+            Assert.AreEqual(Bh, result.HorizontalIntensityAtDepth, 0.01);
+            Assert.AreEqual(Bv, result.VerticalIntensityAtDepth, 0.01);
+            Assert.AreEqual(0.0, result.HorizontalError, 1e-10);
+            Assert.AreEqual(0.0, result.VerticalError, 1e-10);
+        }
+
+        [TestMethod]
+        public void Calculate_1kmDepth_CorrectScalingFactor()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, 1000);
+
+            // R³/(R-D)³ where R=6371200m, D=1000m
+            double R = Constants.EarthsRadiusInKm * 1000;
+            double expected = Math.Pow(R / (R - 1000), 3);
+            Assert.AreEqual(expected, result.DipoleScalingFactor, 1e-8);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_GeomagneticLatitude()
+        {
+            // B_h=20000, B_v=40000 → φ = atan(40000/(2*20000)) = atan(1) = 45°
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(45.0, result.GeomagneticLatitudeDeg, 0.01);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_HorizontalError()
+        {
+            // Eq 3: ΔB_h = 3·B₀·cos(φ)·D/R ≈ 28.2 nT
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(28.2, result.HorizontalError, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_VerticalError()
+        {
+            // Eq 4: ΔB_v = 6·B₀·sin(φ)·D/R ≈ 56.5 nT
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(56.5, result.VerticalError, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_FieldAtDepth()
+        {
+            // B_h(D) ≈ 20028.3, B_v(D) ≈ 40056.5
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual(20028.3, result.HorizontalIntensityAtDepth, 1.0);
+            Assert.AreEqual(40056.5, result.VerticalIntensityAtDepth, 1.0);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_TotalFieldAtDepth()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            double expectedF = F * result.DipoleScalingFactor;
+            Assert.AreEqual(expectedF, result.TotalFieldAtDepth, 0.1);
+            // Also verify it equals sqrt(Bh² + Bv²) at depth
+            double fromComponents = Math.Sqrt(
+                result.HorizontalIntensityAtDepth * result.HorizontalIntensityAtDepth +
+                result.VerticalIntensityAtDepth * result.VerticalIntensityAtDepth);
+            Assert.AreEqual(fromComponents, result.TotalFieldAtDepth, 0.1);
+        }
+
+        #endregion
+
+        #region Null Wellbore Geometry
+
+        [TestMethod]
+        public void Calculate_NullWellboreGeometry_SkipsToolFrameAndAzimuth()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+
+            Assert.IsNull(result.HighSideError);
+            Assert.IsNull(result.HighSideRightError);
+            Assert.IsNull(result.AlongHoleError);
+            Assert.IsNull(result.AzimuthErrorDeg);
+            Assert.IsNull(result.SingularityFactor);
+            Assert.IsNull(result.NearSingularity);
+        }
+
+        #endregion
+
+        #region Magnetic Pole Edge Case
+
+        [TestMethod]
+        public void Calculate_ZeroHorizontalIntensity_MagneticPole()
+        {
+            // At magnetic pole, B_h ≈ 0, B_v is large
+            var result = DepthCorrection.Calculate(0.1, 60000, 60000, DepthM);
+            Assert.AreEqual(90.0, result.GeomagneticLatitudeDeg, 1.0);
+        }
+
+        #endregion
+
+        #region Tool-Frame Errors (Eq 5-7)
+
+        [TestMethod]
+        public void Calculate_WorkedExample_ToolFrameErrors()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            Assert.IsNotNull(result.HighSideError);
+            Assert.IsNotNull(result.HighSideRightError);
+            Assert.IsNotNull(result.AlongHoleError);
+
+            // Compute expected values from equations
+            double B0 = 28284.3;
+            double dOverR = 3000.0 / (Constants.EarthsRadiusInKm * 1000);
+            double cos45 = Math.Cos(45 * Math.PI / 180);
+            double sin45 = Math.Sin(45 * Math.PI / 180);
+            double cos60 = Math.Cos(60 * Math.PI / 180);
+            double sin60 = Math.Sin(60 * Math.PI / 180);
+
+            double expectedH = 3 * B0 * (cos45 * cos45 * cos60 - 2 * sin45 * sin60) * dOverR;
+            double expectedR = -3 * B0 * cos45 * sin45 * dOverR;
+            double expectedA = 3 * B0 * (cos45 * cos45 * sin60 + 2 * sin45 * cos60) * dOverR;
+
+            Assert.AreEqual(expectedH, result.HighSideError.Value, 0.5);
+            Assert.AreEqual(expectedR, result.HighSideRightError.Value, 0.5);
+            Assert.AreEqual(expectedA, result.AlongHoleError.Value, 0.5);
+        }
+
+        [TestMethod]
+        public void Calculate_VerticalWell_ToolFrameErrors()
+        {
+            // I=0° (vertical): cosI=1, sinI=0
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 0, wellboreInclinationDeg: 0);
+
+            // Eq 6: ΔB_R = -3·B₀·cos(φ)·sin(0)·D/R = 0
+            Assert.AreEqual(0.0, result.HighSideRightError.Value, 0.01);
+            // Eq 8: sin(2A)=0, sin(2I)=0 → ΔA = 0
+            Assert.AreEqual(0.0, result.AzimuthErrorDeg.Value, 0.001);
+        }
+
+        [TestMethod]
+        public void Calculate_NorthAzimuth_ToolFrameErrors()
+        {
+            // A=0° (north): sinA=0
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 0, wellboreInclinationDeg: Inclination);
+
+            // Eq 6: ΔB_R = -3·B₀·cos(φ)·sin(0)·D/R = 0
+            Assert.AreEqual(0.0, result.HighSideRightError.Value, 0.01);
+        }
+
+        #endregion
+
+        #region Azimuth Error and Singularity (Eq 8)
+
+        [TestMethod]
+        public void Calculate_WorkedExample_AzimuthError()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            // From spec worked example: ΔA ≈ 0.128°
+            Assert.IsNotNull(result.AzimuthErrorDeg);
+            Assert.AreEqual(0.128, result.AzimuthErrorDeg.Value, 0.01);
+        }
+
+        [TestMethod]
+        public void Calculate_WorkedExample_SingularityFactor()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            // 1 - sin²(45)·sin²(60) = 1 - 0.5·0.75 = 0.625
+            Assert.AreEqual(0.625, result.SingularityFactor.Value, 0.001);
+            Assert.IsFalse(result.NearSingularity.Value);
+        }
+
+        [TestMethod]
+        public void Calculate_NearEastWest_HighInclination_FlagsSingularity()
+        {
+            // A=90° (east), I=85° → singFactor = 1 - sin²(90)·sin²(85) ≈ 1 - 0.9924 = 0.0076
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 90, wellboreInclinationDeg: 85);
+
+            Assert.IsTrue(result.NearSingularity.Value);
+            Assert.IsTrue(result.SingularityFactor.Value < 0.1);
+        }
+
+        #endregion
+
+        #region Convenience Overload
+
+        [TestMethod]
+        public void Calculate_ConvenienceOverload_MatchesPrimitive()
+        {
+            var magCalc = new MagneticCalculations
+            {
+                HorizontalIntensity = new MagneticValue { Value = Bh },
+                VerticalComp = new MagneticValue { Value = Bv },
+                TotalField = new MagneticValue { Value = F }
+            };
+
+            var fromPrimitive = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+            var fromOverload = DepthCorrection.Calculate(magCalc, DepthM,
+                wellboreAzimuthDeg: Azimuth, wellboreInclinationDeg: Inclination);
+
+            Assert.AreEqual(fromPrimitive.DipoleScalingFactor, fromOverload.DipoleScalingFactor, 1e-10);
+            Assert.AreEqual(fromPrimitive.HorizontalIntensityAtDepth, fromOverload.HorizontalIntensityAtDepth, 0.01);
+            Assert.AreEqual(fromPrimitive.VerticalIntensityAtDepth, fromOverload.VerticalIntensityAtDepth, 0.01);
+            Assert.AreEqual(fromPrimitive.AzimuthErrorDeg.Value, fromOverload.AzimuthErrorDeg.Value, 1e-10);
+        }
+
+        #endregion
+
+        #region Metadata
+
+        [TestMethod]
+        public void Calculate_Reference_AlwaysSPE128217()
+        {
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            Assert.AreEqual("SPE-128217-MS", result.Reference);
+        }
+
+        #endregion
+    }
+}

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -276,5 +276,35 @@ namespace GeoMagSharp_UnitTests
         }
 
         #endregion
+
+        #region CalculationOptions Properties
+
+        [TestMethod]
+        public void CalculationOptions_DepthProperties_DefaultToNull()
+        {
+            var options = new CalculationOptions();
+            Assert.IsNull(options.SurveyDepthMeters);
+            Assert.IsNull(options.WellboreAzimuthDeg);
+            Assert.IsNull(options.WellboreInclinationDeg);
+        }
+
+        [TestMethod]
+        public void CalculationOptions_CopyConstructor_CopiesDepthProperties()
+        {
+            var original = new CalculationOptions
+            {
+                SurveyDepthMeters = 3000.0,
+                WellboreAzimuthDeg = 45.0,
+                WellboreInclinationDeg = 60.0
+            };
+
+            var copy = new CalculationOptions(original);
+
+            Assert.AreEqual(3000.0, copy.SurveyDepthMeters);
+            Assert.AreEqual(45.0, copy.WellboreAzimuthDeg);
+            Assert.AreEqual(60.0, copy.WellboreInclinationDeg);
+        }
+
+        #endregion
     }
 }

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -480,7 +480,7 @@ namespace GeoMagSharp_UnitTests
 
             var result = geoMag.ResultsOfCalculation[0];
             Assert.IsNotNull(result.Uncertainty);
-            Assert.AreEqual(0.38, result.Uncertainty.DepthAzimuthUncertainty.Value, 0.001);
+            Assert.AreEqual(DepthCorrection.DepthAzimuthUncertaintyDeg, result.Uncertainty.DepthAzimuthUncertainty.Value, 0.001);
         }
 
         [TestMethod]

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -243,6 +243,83 @@ namespace GeoMagSharp_UnitTests
 
         #endregion
 
+        #region Additional Edge Cases
+
+        [TestMethod]
+        public void Calculate_SouthernHemisphere_NegativeGeomagneticLatitude()
+        {
+            // Negative B_v means southern hemisphere → negative geomagnetic latitude
+            var result = DepthCorrection.Calculate(20000, -40000, 44721.36, DepthM);
+            Assert.IsTrue(result.GeomagneticLatitudeDeg < 0);
+            Assert.AreEqual(-45.0, result.GeomagneticLatitudeDeg, 0.01);
+        }
+
+        [TestMethod]
+        public void Calculate_Equator_ZeroGeomagneticLatitude()
+        {
+            // At magnetic equator, B_v ≈ 0 → φ ≈ 0°
+            var result = DepthCorrection.Calculate(30000, 0.0, 30000, DepthM);
+            Assert.AreEqual(0.0, result.GeomagneticLatitudeDeg, 0.1);
+        }
+
+        [TestMethod]
+        public void Calculate_PartialWellboreGeometry_SkipsToolFrame()
+        {
+            // Only azimuth provided (no inclination) → should skip Eq 5-8
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 45.0, wellboreInclinationDeg: null);
+            Assert.IsNull(result.HighSideError);
+            Assert.IsNull(result.AzimuthErrorDeg);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Calculate_NegativeInclination_ThrowsException()
+        {
+            DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 45, wellboreInclinationDeg: -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Calculate_NullMagneticCalculations_ThrowsException()
+        {
+            DepthCorrection.Calculate((MagneticCalculations)null, DepthM);
+        }
+
+        [TestMethod]
+        public void Calculate_AzimuthWrapping_370DegEquivalentTo10Deg()
+        {
+            var at370 = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 370, wellboreInclinationDeg: 60);
+            var at10 = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 10, wellboreInclinationDeg: 60);
+
+            Assert.AreEqual(at10.AzimuthErrorDeg.Value, at370.AzimuthErrorDeg.Value, 1e-10);
+            Assert.AreEqual(at10.HighSideError.Value, at370.HighSideError.Value, 1e-10);
+        }
+
+        [TestMethod]
+        public void Calculate_DeeperDepth_LargerScalingFactor()
+        {
+            var at1km = DepthCorrection.Calculate(Bh, Bv, F, 1000);
+            var at3km = DepthCorrection.Calculate(Bh, Bv, F, 3000);
+            Assert.IsTrue(at3km.DipoleScalingFactor > at1km.DipoleScalingFactor);
+        }
+
+        [TestMethod]
+        public void Calculate_HorizontalWell_180DegInclination()
+        {
+            // I=180° is valid (past-horizontal, drilling upward)
+            var result = DepthCorrection.Calculate(Bh, Bv, F, DepthM,
+                wellboreAzimuthDeg: 45, wellboreInclinationDeg: 180);
+            Assert.IsNotNull(result.AzimuthErrorDeg);
+            // sin(180)=0, cos(180)=-1 → singularity factor = 1 - 0 = 1
+            Assert.AreEqual(1.0, result.SingularityFactor.Value, 0.001);
+        }
+
+        #endregion
+
         #region Convenience Overload
 
         [TestMethod]

--- a/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/DepthCorrectionUnitTest.cs
@@ -306,5 +306,54 @@ namespace GeoMagSharp_UnitTests
         }
 
         #endregion
+
+        #region MagneticCalculations.DepthCorrection
+
+        [TestMethod]
+        public void MagneticCalculations_DepthCorrection_DefaultsToNull()
+        {
+            var calc = new MagneticCalculations();
+            Assert.IsNull(calc.DepthCorrection);
+        }
+
+        [TestMethod]
+        public void MagneticCalculations_CopyConstructor_CopiesDepthCorrection()
+        {
+            var depthResult = DepthCorrection.Calculate(Bh, Bv, F, DepthM);
+            var original = new MagneticCalculations { DepthCorrection = depthResult };
+            var copy = new MagneticCalculations(original);
+
+            Assert.IsNotNull(copy.DepthCorrection);
+            Assert.AreEqual(original.DepthCorrection.DipoleScalingFactor, copy.DepthCorrection.DipoleScalingFactor);
+        }
+
+        #endregion
+
+        #region GeomagneticUncertainty.DepthAzimuthUncertainty
+
+        [TestMethod]
+        public void GeomagneticUncertainty_DepthAzimuthUncertainty_DefaultsToNull()
+        {
+            var unc = new GeomagneticUncertainty();
+            Assert.IsNull(unc.DepthAzimuthUncertainty);
+        }
+
+        [TestMethod]
+        public void GeomagneticUncertainty_ScaleTo_ScalesDepthAzimuthUncertainty()
+        {
+            var unc = new GeomagneticUncertainty { DepthAzimuthUncertainty = 0.38 };
+            var scaled = unc.ScaleTo(2.0);
+            Assert.AreEqual(0.76, scaled.DepthAzimuthUncertainty.Value, 1e-10);
+        }
+
+        [TestMethod]
+        public void GeomagneticUncertainty_ScaleTo_NullDepthAzimuth_StaysNull()
+        {
+            var unc = new GeomagneticUncertainty { DepthAzimuthUncertainty = null };
+            var scaled = unc.ScaleTo(2.0);
+            Assert.IsNull(scaled.DepthAzimuthUncertainty);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary
- Implements dipole depth correction per SPE-128217-MS (Ekseth & Weston, 2010)
- Standalone `DepthCorrection.Calculate()` API with primitive and `MagneticCalculations` overloads
- Pipeline integration via `CalculationOptions.SurveyDepthMeters` with optional wellbore geometry
- Adds `DepthAzimuthUncertainty` (σ_ΔA = 0.38°) to `GeomagneticUncertainty`

## What's Included
- **Eq 1-2**: Field at depth via R³/(R-D)³ dipole scaling
- **Eq 3-4**: First-order horizontal/vertical error approximations
- **Eq 5-7**: Tool-frame error components (high-side, high-side-right, along-hole)
- **Eq 8**: Azimuth error with east-west singularity detection
- 34 tests (27 unit + 7 integration with WMM2025)

## Test plan
- [x] All 173 tests pass (171 passed, 2 pre-existing skips)
- [x] Build succeeds on both net48 and netstandard2.0
- [ ] Ralph Loop review cycles (pending)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)