### PR TITLE
feat: WMM native error model with location-dependent uncertainty (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ if (result.Uncertainty != null)
     Console.WriteLine($"Category:    {result.Uncertainty.ModelCategory}");
     Console.WriteLine($"Declination: +/-{result.Uncertainty.Declination:F2} deg (1-sigma)");
     Console.WriteLine($"Total Field: +/-{result.Uncertainty.TotalField:F0} nT (1-sigma)");
-    Console.WriteLine($"Dip Angle:   +/-{result.Uncertainty.DipAngle:F2} deg (1-sigma)");
+    Console.WriteLine($"Inclination: +/-{result.Uncertainty.Inclination:F2} deg (1-sigma)");
 
     // Scale to approximate 2-sigma
     var u2 = result.Uncertainty.ScaleTo(2.0);

--- a/docs/features/13-wmm-error-model/tasks.md
+++ b/docs/features/13-wmm-error-model/tasks.md
@@ -21,4 +21,4 @@ Branch: feature/13-wmm-error-model
 - [x] All tasks checked
 - [x] Build succeeds
 - [x] Tests pass
-- [ ] 2 clean Ralph Loop cycles
+- [x] 2 clean Ralph Loop cycles

--- a/docs/features/13-wmm-error-model/tasks.md
+++ b/docs/features/13-wmm-error-model/tasks.md
@@ -3,22 +3,22 @@ Issue: #13
 Branch: feature/13-wmm-error-model
 
 ## Tasks
-- [ ] Add `UncertaintyModelPreference` enum (Auto, Iscwsa, Native)
-- [ ] Add `UncertaintyModel` property to `CalculationOptions`
-- [ ] Create `wmm-error-model.json` embedded resource with WMM2025 and WMMHR2025 constants
-- [ ] Add JSON POCO classes for WMM error model deserialization
-- [ ] Add new properties to `GeomagneticUncertainty` (X, Y, Z, H + UncertaintySource)
-- [ ] Extend `UncertaintyDataProvider` to resolve WMM error model when applicable
-- [ ] Compute δD from H at each location using δD = √(base² + (coeff/H)²)
-- [ ] Integrate WMM uncertainty into GeoMag calculation pipeline
-- [ ] Add unit tests for WMM error model constants
-- [ ] Add unit tests for δD computation at multiple H values
-- [ ] Add integration test verifying against NOAA calculator output (41.31°N, 81.33°W)
-- [ ] Verify backward compatibility: existing ISCWSA behavior preserved with Iscwsa override
-- [ ] Verify build succeeds with 0 errors
+- [x] Add `UncertaintyModelPreference` enum (Auto, Iscwsa, Native)
+- [x] Add `UncertaintyModel` property to `CalculationOptions`
+- [x] Create `wmm-error-model.json` embedded resource with WMM2025 and WMMHR2025 constants
+- [x] Add JSON POCO classes for WMM error model deserialization
+- [x] Add new properties to `GeomagneticUncertainty` (X, Y, Z, H + UncertaintySource)
+- [x] Extend `UncertaintyDataProvider` to resolve WMM error model when applicable
+- [x] Compute δD from H at each location using δD = √(base² + (coeff/H)²)
+- [x] Integrate WMM uncertainty into GeoMag calculation pipeline
+- [x] Add unit tests for WMM error model constants
+- [x] Add unit tests for δD computation at multiple H values
+- [x] Add integration test verifying against NOAA calculator output (41.31°N, 81.33°W)
+- [x] Verify backward compatibility: existing ISCWSA behavior preserved with Iscwsa override
+- [x] Verify build succeeds with 0 errors
 
 ## Completion Criteria
-- [ ] All tasks checked
-- [ ] Build succeeds
-- [ ] Tests pass
+- [x] All tasks checked
+- [x] Build succeeds
+- [x] Tests pass
 - [ ] 2 clean Ralph Loop cycles

--- a/docs/features/13-wmm-error-model/tasks.md
+++ b/docs/features/13-wmm-error-model/tasks.md
@@ -1,0 +1,24 @@
+# Feature: WMM Location-Dependent Uncertainty (Level 2)
+Issue: #13
+Branch: feature/13-wmm-error-model
+
+## Tasks
+- [ ] Add `UncertaintyModelPreference` enum (Auto, Iscwsa, Native)
+- [ ] Add `UncertaintyModel` property to `CalculationOptions`
+- [ ] Create `wmm-error-model.json` embedded resource with WMM2025 and WMMHR2025 constants
+- [ ] Add JSON POCO classes for WMM error model deserialization
+- [ ] Add new properties to `GeomagneticUncertainty` (X, Y, Z, H + UncertaintySource)
+- [ ] Extend `UncertaintyDataProvider` to resolve WMM error model when applicable
+- [ ] Compute δD from H at each location using δD = √(base² + (coeff/H)²)
+- [ ] Integrate WMM uncertainty into GeoMag calculation pipeline
+- [ ] Add unit tests for WMM error model constants
+- [ ] Add unit tests for δD computation at multiple H values
+- [ ] Add integration test verifying against NOAA calculator output (41.31°N, 81.33°W)
+- [ ] Verify backward compatibility: existing ISCWSA behavior preserved with Iscwsa override
+- [ ] Verify build succeeds with 0 errors
+
+## Completion Criteria
+- [ ] All tasks checked
+- [ ] Build succeeds
+- [ ] Tests pass
+- [ ] 2 clean Ralph Loop cycles

--- a/examples/GeoMagSharp.Example/Program.cs
+++ b/examples/GeoMagSharp.Example/Program.cs
@@ -61,7 +61,7 @@ namespace GeoMagSharp.Example
                 Console.WriteLine($"    Declination: +/-{u.Declination:F2} deg");
                 Console.WriteLine($"    Bh-dep Dec:  +/-{u.BhDependentDec:F0} deg*nT");
                 Console.WriteLine($"    Total Field: +/-{u.TotalField:F0} nT");
-                Console.WriteLine($"    Dip Angle:   +/-{u.DipAngle:F2} deg");
+                Console.WriteLine($"    Inclination:   +/-{u.Inclination:F2} deg");
             }
             else
             {
@@ -81,7 +81,7 @@ namespace GeoMagSharp.Example
                 var u2 = result.Uncertainty.ScaleTo(2.0);
                 Console.WriteLine($"    Declination: +/-{u2.Declination:F2} deg");
                 Console.WriteLine($"    Total Field: +/-{u2.TotalField:F0} nT");
-                Console.WriteLine($"    Dip Angle:   +/-{u2.DipAngle:F2} deg");
+                Console.WriteLine($"    Inclination:   +/-{u2.Inclination:F2} deg");
                 Console.WriteLine();
                 Console.WriteLine("  Note: Geomagnetic errors follow a Laplacian distribution,");
                 Console.WriteLine("  so scaled values are approximate at levels other than 1-sigma.");

--- a/src/GeoMagSharp/Data/wmm-error-model.json
+++ b/src/GeoMagSharp/Data/wmm-error-model.json
@@ -1,0 +1,30 @@
+{
+  "source": "US/UK World Magnetic Model 2025-2030 Technical Report (Chulliat et al., 2025), Section 3.4",
+  "reference": "https://doi.org/10.25923/prbc-s316",
+  "models": {
+    "WMM2025": {
+      "validFrom": 2025.0,
+      "validTo": 2030.0,
+      "northIntensity": 137,
+      "eastIntensity": 89,
+      "verticalIntensity": 141,
+      "horizontalIntensity": 133,
+      "totalField": 138,
+      "inclination": 0.20,
+      "declinationBase": 0.26,
+      "declinationCoeff": 5417
+    },
+    "WMMHR2025": {
+      "validFrom": 2025.0,
+      "validTo": 2030.0,
+      "northIntensity": 135,
+      "eastIntensity": 85,
+      "verticalIntensity": 134,
+      "horizontalIntensity": 130,
+      "totalField": 134,
+      "inclination": 0.19,
+      "declinationBase": 0.25,
+      "declinationCoeff": 5205
+    }
+  }
+}

--- a/src/GeoMagSharp/Enums/GeoMagEnums.cs
+++ b/src/GeoMagSharp/Enums/GeoMagEnums.cs
@@ -135,4 +135,42 @@ namespace GeoMagSharp
         /// </summary>
         InFieldReference2 = 5
     }
+
+    /// <summary>
+    /// Controls which uncertainty model is used for geomagnetic calculations.
+    /// </summary>
+    public enum UncertaintyModelPreference
+    {
+        /// <summary>
+        /// Automatic selection: uses the WMM error model for WMM/WMMHR models,
+        /// ISCWSA Level 1 for all other models.
+        /// </summary>
+        Auto = 0,
+
+        /// <summary>
+        /// Force ISCWSA Level 1 uncertainty for all model types.
+        /// </summary>
+        Iscwsa = 1,
+
+        /// <summary>
+        /// Force the model's native error model. Throws if the model has no native error model.
+        /// </summary>
+        Native = 2
+    }
+
+    /// <summary>
+    /// Identifies which uncertainty model produced the uncertainty values.
+    /// </summary>
+    public enum UncertaintySource
+    {
+        /// <summary>
+        /// ISCWSA Level 1 global constants (CDR-SM-03 Rev 8)
+        /// </summary>
+        Iscwsa = 0,
+
+        /// <summary>
+        /// WMM/WMMHR native error model with location-dependent declination uncertainty
+        /// </summary>
+        WmmErrorModel = 1
+    }
 }

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -130,9 +130,6 @@ namespace GeoMagSharp
 
             _CalculationOptions = new CalculationOptions(inCalculationOptions);
 
-            var uncertainty = UncertaintyDataProvider.GetUncertainty(
-                _Models.Type, _CalculationOptions.ModelCategoryOverride);
-
             while (dateIdx <= timespan.Days)
             {
 
@@ -148,7 +145,12 @@ namespace GeoMagSharp
 
                 if (magCalcDate != null)
                 {
-                    magCalcDate.Uncertainty = uncertainty;
+                    magCalcDate.Uncertainty = UncertaintyDataProvider.GetUncertainty(
+                        _Models.Type,
+                        _CalculationOptions.ModelCategoryOverride,
+                        _CalculationOptions.UncertaintyModel,
+                        magCalcDate.HorizontalIntensity.Value);
+
                     ApplyDepthCorrection(magCalcDate, _CalculationOptions);
                     ResultsOfCalculation.Add(magCalcDate);
                 }
@@ -506,10 +508,15 @@ namespace GeoMagSharp
                 magCalc.Uncertainty = new GeomagneticUncertainty
                 {
                     ModelCategory = magCalc.Uncertainty.ModelCategory,
+                    Source = magCalc.Uncertainty.Source,
                     Declination = magCalc.Uncertainty.Declination,
                     BhDependentDec = magCalc.Uncertainty.BhDependentDec,
                     TotalField = magCalc.Uncertainty.TotalField,
                     DipAngle = magCalc.Uncertainty.DipAngle,
+                    NorthIntensity = magCalc.Uncertainty.NorthIntensity,
+                    EastIntensity = magCalc.Uncertainty.EastIntensity,
+                    VerticalIntensity = magCalc.Uncertainty.VerticalIntensity,
+                    HorizontalIntensity = magCalc.Uncertainty.HorizontalIntensity,
                     Revision = magCalc.Uncertainty.Revision,
                     DepthAzimuthUncertainty = DepthCorrection.DepthAzimuthUncertaintyDeg
                 };

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -335,9 +335,6 @@ namespace GeoMagSharp
 
             _CalculationOptions = new CalculationOptions(inCalculationOptions);
 
-            var uncertainty = UncertaintyDataProvider.GetUncertainty(
-                _Models.Type, _CalculationOptions.ModelCategoryOverride);
-
             while (dateIdx <= timespan.Days)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -366,7 +363,12 @@ namespace GeoMagSharp
 
                 if (magCalcDate != null)
                 {
-                    magCalcDate.Uncertainty = uncertainty;
+                    magCalcDate.Uncertainty = UncertaintyDataProvider.GetUncertainty(
+                        _Models.Type,
+                        _CalculationOptions.ModelCategoryOverride,
+                        _CalculationOptions.UncertaintyModel,
+                        magCalcDate.HorizontalIntensity.Value);
+
                     ApplyDepthCorrection(magCalcDate, _CalculationOptions);
                     ResultsOfCalculation.Add(magCalcDate);
                 }

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -514,7 +514,7 @@ namespace GeoMagSharp
                     Declination = magCalc.Uncertainty.Declination,
                     BhDependentDec = magCalc.Uncertainty.BhDependentDec,
                     TotalField = magCalc.Uncertainty.TotalField,
-                    DipAngle = magCalc.Uncertainty.DipAngle,
+                    Inclination = magCalc.Uncertainty.Inclination,
                     NorthIntensity = magCalc.Uncertainty.NorthIntensity,
                     EastIntensity = magCalc.Uncertainty.EastIntensity,
                     VerticalIntensity = magCalc.Uncertainty.VerticalIntensity,

--- a/src/GeoMagSharp/GeoMagSharp.csproj
+++ b/src/GeoMagSharp/GeoMagSharp.csproj
@@ -34,4 +34,10 @@
     <EmbeddedResource Include="Data\wmm-error-model.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>GeoMagSharp.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/GeoMagSharp/GeoMagSharp.csproj
+++ b/src/GeoMagSharp/GeoMagSharp.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Data\iscwsa-uncertainty.json" />
+    <EmbeddedResource Include="Data\wmm-error-model.json" />
   </ItemGroup>
 
 </Project>

--- a/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
+++ b/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
@@ -38,6 +38,8 @@ namespace GeoMagSharp
             SurveyDepthMeters = null;
             WellboreAzimuthDeg = null;
             WellboreInclinationDeg = null;
+
+            UncertaintyModel = UncertaintyModelPreference.Auto;
         }
 
         /// <summary>
@@ -62,6 +64,8 @@ namespace GeoMagSharp
             SurveyDepthMeters = other.SurveyDepthMeters;
             WellboreAzimuthDeg = other.WellboreAzimuthDeg;
             WellboreInclinationDeg = other.WellboreInclinationDeg;
+
+            UncertaintyModel = other.UncertaintyModel;
         }
 
         #endregion
@@ -109,6 +113,12 @@ namespace GeoMagSharp
         /// Wellbore inclination (degrees, 0-180). Null to skip tool-frame error calculations (Eq 5-8).
         /// </summary>
         public double? WellboreInclinationDeg { get; set; }
+
+        /// <summary>
+        /// Controls which uncertainty model is used. Default is Auto (WMM error model for WMM/WMMHR,
+        /// ISCWSA for all other models).
+        /// </summary>
+        public UncertaintyModelPreference UncertaintyModel { get; set; }
 
         #region Getters & Setters
 

--- a/src/GeoMagSharp/Models/Configuration/WmmErrorModelData.cs
+++ b/src/GeoMagSharp/Models/Configuration/WmmErrorModelData.cs
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * File:            WmmErrorModelData.cs
+ * Description:     Internal POCOs for WMM error model JSON deserialization
+ * Author:          Christopher Strecker
+ * Website:         https://github.com/StreckerCM/GeoMagSharp
+ ****************************************************************************/
+
+using System.Collections.Generic;
+
+namespace GeoMagSharp
+{
+    /// <summary>
+    /// Root object for WMM error model JSON data.
+    /// Internal — consumers use <see cref="GeomagneticUncertainty"/> instead.
+    /// </summary>
+    internal class WmmErrorModelData
+    {
+        public string Source { get; set; }
+        public string Reference { get; set; }
+        public Dictionary<string, WmmErrorModelEntry> Models { get; set; }
+    }
+
+    /// <summary>
+    /// Error model constants for a single WMM model epoch.
+    /// </summary>
+    internal class WmmErrorModelEntry
+    {
+        public double ValidFrom { get; set; }
+        public double ValidTo { get; set; }
+
+        /// <summary>δX — North component uncertainty (nT)</summary>
+        public double NorthIntensity { get; set; }
+
+        /// <summary>δY — East component uncertainty (nT)</summary>
+        public double EastIntensity { get; set; }
+
+        /// <summary>δZ — Vertical component uncertainty (nT)</summary>
+        public double VerticalIntensity { get; set; }
+
+        /// <summary>δH — Horizontal intensity uncertainty (nT)</summary>
+        public double HorizontalIntensity { get; set; }
+
+        /// <summary>δF — Total field uncertainty (nT)</summary>
+        public double TotalField { get; set; }
+
+        /// <summary>δI — Inclination uncertainty (degrees)</summary>
+        public double Inclination { get; set; }
+
+        /// <summary>C₁ — Base declination uncertainty constant (degrees)</summary>
+        public double DeclinationBase { get; set; }
+
+        /// <summary>C₂ — Declination H-dependent coefficient (nT·degrees)</summary>
+        public double DeclinationCoeff { get; set; }
+    }
+}

--- a/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
+++ b/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
@@ -8,13 +8,15 @@
 namespace GeoMagSharp
 {
     /// <summary>
-    /// ISCWSA-based 1-sigma geomagnetic uncertainty values for a model category.
-    /// Values are from CDR-SM-03 Rev 8 (Copsegrove, 2013) Table 2.
+    /// 1-sigma geomagnetic uncertainty values from either ISCWSA Level 1 or WMM native error model.
     /// </summary>
     public class GeomagneticUncertainty
     {
         /// <summary>The ISCWSA model category these values apply to.</summary>
         public GeomagneticModelCategory ModelCategory { get; set; }
+
+        /// <summary>Identifies which uncertainty model produced these values.</summary>
+        public UncertaintySource Source { get; set; }
 
         /// <summary>Declination uncertainty in degrees, 1-sigma (ISCWSA DEC term).</summary>
         public double Declination { get; set; }
@@ -22,19 +24,32 @@ namespace GeoMagSharp
         /// <summary>
         /// Bh-dependent declination uncertainty in deg·nT, 1-sigma (ISCWSA DBH term).
         /// Effective declination error = BhDependentDec / Bh, where Bh is horizontal field intensity.
+        /// For WMM error model, this is 0 because declination uncertainty is computed directly.
         /// </summary>
         public double BhDependentDec { get; set; }
 
-        /// <summary>Total field intensity uncertainty in nT, 1-sigma (ISCWSA MFI term).</summary>
+        /// <summary>Total field intensity uncertainty in nT, 1-sigma (ISCWSA MFI term / WMM δF).</summary>
         public double TotalField { get; set; }
 
         /// <summary>
-        /// Dip angle (inclination) uncertainty in degrees, 1-sigma (ISCWSA MDI term).
+        /// Dip angle (inclination) uncertainty in degrees, 1-sigma (ISCWSA MDI term / WMM δI).
         /// Same physical quantity as MagneticCalculations.Inclination.
         /// </summary>
         public double DipAngle { get; set; }
 
-        /// <summary>ISCWSA error model revision (e.g., "Rev5.13").</summary>
+        /// <summary>North component (X) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
+        public double? NorthIntensity { get; set; }
+
+        /// <summary>East component (Y) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
+        public double? EastIntensity { get; set; }
+
+        /// <summary>Vertical component (Z) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
+        public double? VerticalIntensity { get; set; }
+
+        /// <summary>Horizontal intensity (H) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
+        public double? HorizontalIntensity { get; set; }
+
+        /// <summary>ISCWSA error model revision (e.g., "Rev5.13") or WMM error model source.</summary>
         public string Revision { get; set; }
 
         /// <summary>
@@ -55,10 +70,15 @@ namespace GeoMagSharp
             return new GeomagneticUncertainty
             {
                 ModelCategory = ModelCategory,
+                Source = Source,
                 Declination = Declination * scaleFactor,
                 BhDependentDec = BhDependentDec * scaleFactor,
                 TotalField = TotalField * scaleFactor,
                 DipAngle = DipAngle * scaleFactor,
+                NorthIntensity = NorthIntensity.HasValue ? NorthIntensity.Value * scaleFactor : (double?)null,
+                EastIntensity = EastIntensity.HasValue ? EastIntensity.Value * scaleFactor : (double?)null,
+                VerticalIntensity = VerticalIntensity.HasValue ? VerticalIntensity.Value * scaleFactor : (double?)null,
+                HorizontalIntensity = HorizontalIntensity.HasValue ? HorizontalIntensity.Value * scaleFactor : (double?)null,
                 Revision = Revision,
                 DepthAzimuthUncertainty = DepthAzimuthUncertainty.HasValue
                     ? DepthAzimuthUncertainty.Value * scaleFactor

--- a/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
+++ b/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
@@ -5,59 +5,76 @@
  * Website:         https://github.com/StreckerCM/GeoMagSharp
  ****************************************************************************/
 
+using System;
+
 namespace GeoMagSharp
 {
     /// <summary>
     /// 1-sigma geomagnetic uncertainty values from either ISCWSA Level 1 or WMM native error model.
+    /// Instances are created by the library and are effectively immutable to external consumers.
     /// </summary>
     public class GeomagneticUncertainty
     {
         /// <summary>The ISCWSA model category these values apply to.</summary>
-        public GeomagneticModelCategory ModelCategory { get; set; }
+        public GeomagneticModelCategory ModelCategory { get; internal set; }
 
         /// <summary>Identifies which uncertainty model produced these values.</summary>
-        public UncertaintySource Source { get; set; }
+        public UncertaintySource Source { get; internal set; }
 
-        /// <summary>Declination uncertainty in degrees, 1-sigma (ISCWSA DEC term).</summary>
-        public double Declination { get; set; }
+        /// <summary>
+        /// Declination uncertainty in degrees, 1-sigma (ISCWSA DEC term / WMM δD).
+        /// When the WMM error model is used at H=0 (magnetic dip pole), this is set to 999.0
+        /// to indicate that declination is undefined. Check for values >= 999.0 to detect this case.
+        /// </summary>
+        public double Declination { get; internal set; }
 
         /// <summary>
         /// Bh-dependent declination uncertainty in deg·nT, 1-sigma (ISCWSA DBH term).
         /// Effective declination error = BhDependentDec / Bh, where Bh is horizontal field intensity.
         /// For WMM error model, this is 0 because declination uncertainty is computed directly.
         /// </summary>
-        public double BhDependentDec { get; set; }
+        public double BhDependentDec { get; internal set; }
 
         /// <summary>Total field intensity uncertainty in nT, 1-sigma (ISCWSA MFI term / WMM δF).</summary>
-        public double TotalField { get; set; }
+        public double TotalField { get; internal set; }
 
         /// <summary>
-        /// Dip angle (inclination) uncertainty in degrees, 1-sigma (ISCWSA MDI term / WMM δI).
-        /// Same physical quantity as MagneticCalculations.Inclination.
+        /// Inclination uncertainty in degrees, 1-sigma (ISCWSA MDI term / WMM δI).
+        /// Same physical quantity as <see cref="MagneticCalculations.Inclination"/>.
         /// </summary>
-        public double DipAngle { get; set; }
+        public double Inclination { get; internal set; }
+
+        /// <summary>
+        /// Dip angle (inclination) uncertainty in degrees, 1-sigma.
+        /// </summary>
+        [Obsolete("Use Inclination instead. DipAngle will be removed in a future version.")]
+        public double DipAngle
+        {
+            get { return Inclination; }
+            set { Inclination = value; }
+        }
 
         /// <summary>North component (X) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
-        public double? NorthIntensity { get; set; }
+        public double? NorthIntensity { get; internal set; }
 
         /// <summary>East component (Y) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
-        public double? EastIntensity { get; set; }
+        public double? EastIntensity { get; internal set; }
 
         /// <summary>Vertical component (Z) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
-        public double? VerticalIntensity { get; set; }
+        public double? VerticalIntensity { get; internal set; }
 
         /// <summary>Horizontal intensity (H) uncertainty in nT, 1-sigma. Null for ISCWSA source.</summary>
-        public double? HorizontalIntensity { get; set; }
+        public double? HorizontalIntensity { get; internal set; }
 
         /// <summary>ISCWSA error model revision (e.g., "Rev5.13") or WMM error model source.</summary>
-        public string Revision { get; set; }
+        public string Revision { get; internal set; }
 
         /// <summary>
         /// Depth-dependent azimuth uncertainty in degrees, 1-sigma.
-        /// From SPE-128217-MS Monte Carlo analysis: σ_ΔA ≈ 0.38° global average.
+        /// From SPE-128217-MS Monte Carlo analysis: sigma_DeltaA = 0.38 deg global average.
         /// Null if depth correction was not applied.
         /// </summary>
-        public double? DepthAzimuthUncertainty { get; set; }
+        public double? DepthAzimuthUncertainty { get; internal set; }
 
         /// <summary>
         /// Returns a new instance with all uncertainty values multiplied by the given scale factor.
@@ -74,7 +91,7 @@ namespace GeoMagSharp
                 Declination = Declination * scaleFactor,
                 BhDependentDec = BhDependentDec * scaleFactor,
                 TotalField = TotalField * scaleFactor,
-                DipAngle = DipAngle * scaleFactor,
+                Inclination = Inclination * scaleFactor,
                 NorthIntensity = NorthIntensity.HasValue ? NorthIntensity.Value * scaleFactor : (double?)null,
                 EastIntensity = EastIntensity.HasValue ? EastIntensity.Value * scaleFactor : (double?)null,
                 VerticalIntensity = VerticalIntensity.HasValue ? VerticalIntensity.Value * scaleFactor : (double?)null,

--- a/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
+++ b/src/GeoMagSharp/Models/Results/GeomagneticUncertainty.cs
@@ -1,6 +1,6 @@
 /****************************************************************************
  * File:            GeomagneticUncertainty.cs
- * Description:     ISCWSA-based geomagnetic uncertainty values
+ * Description:     Geomagnetic uncertainty values (ISCWSA or WMM error model)
  * Author:          Christopher Strecker
  * Website:         https://github.com/StreckerCM/GeoMagSharp
  ****************************************************************************/

--- a/src/GeoMagSharp/Models/Results/MagneticCalculations.cs
+++ b/src/GeoMagSharp/Models/Results/MagneticCalculations.cs
@@ -149,7 +149,7 @@ namespace GeoMagSharp
         public MagneticValue TotalField { get; set; }
 
         /// <summary>
-        /// ISCWSA-based 1-sigma geomagnetic uncertainty for this calculation.
+        /// 1-sigma geomagnetic uncertainty for this calculation (ISCWSA or WMM error model).
         /// Null if model category is Unknown and no override was provided.
         /// </summary>
         public GeomagneticUncertainty Uncertainty { get; set; }

--- a/src/GeoMagSharp/UncertaintyDataProvider.cs
+++ b/src/GeoMagSharp/UncertaintyDataProvider.cs
@@ -91,7 +91,7 @@ namespace GeoMagSharp
         /// <param name="model">The detected model type.</param>
         /// <param name="overrideCategory">Optional manual override for model category.</param>
         /// <returns>Uncertainty values, or null if category is Unknown.</returns>
-        public static GeomagneticUncertainty GetIscwsaUncertainty(knownModels model, GeomagneticModelCategory? overrideCategory)
+        internal static GeomagneticUncertainty GetIscwsaUncertainty(knownModels model, GeomagneticModelCategory? overrideCategory)
         {
             var category = GetModelCategory(model, overrideCategory);
 
@@ -113,7 +113,7 @@ namespace GeoMagSharp
                 Declination = values.Declination,
                 BhDependentDec = values.BhDependentDec,
                 TotalField = values.TotalField,
-                DipAngle = values.DipAngle,
+                Inclination = values.DipAngle,
                 Revision = data.Revision
             };
         }
@@ -124,7 +124,7 @@ namespace GeoMagSharp
         /// <param name="model">The model type (must be WMM or WMMHR).</param>
         /// <param name="horizontalIntensity">Horizontal field intensity (nT) for δD calculation.</param>
         /// <returns>Uncertainty values with location-dependent declination.</returns>
-        public static GeomagneticUncertainty GetWmmUncertainty(knownModels model, double horizontalIntensity)
+        internal static GeomagneticUncertainty GetWmmUncertainty(knownModels model, double horizontalIntensity)
         {
             string modelKey;
             var entry = ResolveWmmErrorModelEntry(model, out modelKey);
@@ -143,7 +143,7 @@ namespace GeoMagSharp
                 Declination = declination,
                 BhDependentDec = 0,
                 TotalField = entry.TotalField,
-                DipAngle = entry.Inclination,
+                Inclination = entry.Inclination,
                 NorthIntensity = entry.NorthIntensity,
                 EastIntensity = entry.EastIntensity,
                 VerticalIntensity = entry.VerticalIntensity,
@@ -161,7 +161,15 @@ namespace GeoMagSharp
         /// <returns>Declination uncertainty in degrees.</returns>
         internal static double ComputeDeclinationUncertainty(double declinationBase, double declinationCoeff, double horizontalIntensity)
         {
-            if (horizontalIntensity <= 0)
+            if (double.IsNaN(horizontalIntensity) || double.IsInfinity(horizontalIntensity))
+                throw new ArgumentOutOfRangeException(nameof(horizontalIntensity),
+                    horizontalIntensity, "Horizontal intensity must be a finite number.");
+
+            if (horizontalIntensity < 0)
+                throw new ArgumentOutOfRangeException(nameof(horizontalIntensity),
+                    horizontalIntensity, "Horizontal intensity cannot be negative.");
+
+            if (horizontalIntensity == 0)
                 return 999.0;
 
             double baseSq = declinationBase * declinationBase;
@@ -244,7 +252,13 @@ namespace GeoMagSharp
                 using (var reader = new StreamReader(stream))
                 {
                     var json = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<T>(json);
+                    var result = JsonConvert.DeserializeObject<T>(json);
+
+                    if (result == null)
+                        throw new InvalidOperationException(
+                            $"Failed to deserialize embedded resource '{resourceName}'. The JSON content could not be parsed into {typeof(T).Name}.");
+
+                    return result;
                 }
             }
         }

--- a/src/GeoMagSharp/UncertaintyDataProvider.cs
+++ b/src/GeoMagSharp/UncertaintyDataProvider.cs
@@ -1,6 +1,6 @@
 /****************************************************************************
  * File:            UncertaintyDataProvider.cs
- * Description:     Loads and provides ISCWSA uncertainty data
+ * Description:     Loads and provides geomagnetic uncertainty data
  * Author:          Christopher Strecker
  * Website:         https://github.com/StreckerCM/GeoMagSharp
  ****************************************************************************/
@@ -13,12 +13,13 @@ using Newtonsoft.Json;
 namespace GeoMagSharp
 {
     /// <summary>
-    /// Provides ISCWSA-based geomagnetic uncertainty values.
-    /// Loads data from embedded JSON resource on first access (thread-safe).
+    /// Provides geomagnetic uncertainty values from ISCWSA Level 1 or WMM native error model.
+    /// Loads data from embedded JSON resources on first access (thread-safe).
     /// </summary>
     public static class UncertaintyDataProvider
     {
-        private static readonly Lazy<UncertaintyData> _data = new Lazy<UncertaintyData>(LoadEmbeddedData);
+        private static readonly Lazy<UncertaintyData> _iscwsaData = new Lazy<UncertaintyData>(LoadIscwsaData);
+        private static readonly Lazy<WmmErrorModelData> _wmmData = new Lazy<WmmErrorModelData>(LoadWmmData);
 
         /// <summary>
         /// Maps a <see cref="knownModels"/> value to its ISCWSA model category.
@@ -49,18 +50,55 @@ namespace GeoMagSharp
 
         /// <summary>
         /// Gets the ISCWSA uncertainty values for the given model and optional category override.
+        /// Backward-compatible overload — always uses ISCWSA Level 1.
+        /// Use the 4-parameter overload for WMM error model support.
+        /// </summary>
+        public static GeomagneticUncertainty GetUncertainty(knownModels model, GeomagneticModelCategory? overrideCategory)
+        {
+            return GetIscwsaUncertainty(model, overrideCategory);
+        }
+
+        /// <summary>
+        /// Gets uncertainty values based on the model type and uncertainty preference.
+        /// </summary>
+        /// <param name="model">The detected model type.</param>
+        /// <param name="overrideCategory">Optional manual override for ISCWSA model category.</param>
+        /// <param name="preference">Which uncertainty model to use (Auto, Iscwsa, or Native).</param>
+        /// <param name="horizontalIntensity">Horizontal field intensity (nT) for location-dependent δD. Required for WMM error model.</param>
+        /// <returns>Uncertainty values, or null if category is Unknown and ISCWSA is selected.</returns>
+        public static GeomagneticUncertainty GetUncertainty(
+            knownModels model,
+            GeomagneticModelCategory? overrideCategory,
+            UncertaintyModelPreference preference,
+            double horizontalIntensity)
+        {
+            // If ModelCategoryOverride is set, the caller explicitly wants ISCWSA
+            // for that category (e.g., IFR1), so skip the WMM error model.
+            if (overrideCategory.HasValue)
+                return GetIscwsaUncertainty(model, overrideCategory);
+
+            bool useWmm = ShouldUseWmmErrorModel(model, preference);
+
+            if (useWmm)
+                return GetWmmUncertainty(model, horizontalIntensity);
+
+            return GetIscwsaUncertainty(model, overrideCategory);
+        }
+
+        /// <summary>
+        /// Gets the ISCWSA uncertainty values for the given model and optional category override.
         /// </summary>
         /// <param name="model">The detected model type.</param>
         /// <param name="overrideCategory">Optional manual override for model category.</param>
         /// <returns>Uncertainty values, or null if category is Unknown.</returns>
-        public static GeomagneticUncertainty GetUncertainty(knownModels model, GeomagneticModelCategory? overrideCategory)
+        public static GeomagneticUncertainty GetIscwsaUncertainty(knownModels model, GeomagneticModelCategory? overrideCategory)
         {
             var category = GetModelCategory(model, overrideCategory);
 
             if (category == GeomagneticModelCategory.Unknown)
                 return null;
 
-            var data = _data.Value;
+            var data = _iscwsaData.Value;
             var categoryName = category.ToString();
 
             if (!data.Categories.ContainsKey(categoryName))
@@ -71,6 +109,7 @@ namespace GeoMagSharp
             return new GeomagneticUncertainty
             {
                 ModelCategory = category,
+                Source = UncertaintySource.Iscwsa,
                 Declination = values.Declination,
                 BhDependentDec = values.BhDependentDec,
                 TotalField = values.TotalField,
@@ -79,21 +118,132 @@ namespace GeoMagSharp
             };
         }
 
-        private static UncertaintyData LoadEmbeddedData()
+        /// <summary>
+        /// Gets WMM native error model uncertainty values with location-dependent declination.
+        /// </summary>
+        /// <param name="model">The model type (must be WMM or WMMHR).</param>
+        /// <param name="horizontalIntensity">Horizontal field intensity (nT) for δD calculation.</param>
+        /// <returns>Uncertainty values with location-dependent declination.</returns>
+        public static GeomagneticUncertainty GetWmmUncertainty(knownModels model, double horizontalIntensity)
+        {
+            var entry = ResolveWmmErrorModelEntry(model);
+
+            if (entry == null)
+                throw new InvalidOperationException(
+                    $"No WMM error model data found for model type '{model}'. " +
+                    "The WMM error model is only available for WMM and WMMHR models.");
+
+            double declination = ComputeDeclinationUncertainty(entry.DeclinationBase, entry.DeclinationCoeff, horizontalIntensity);
+
+            return new GeomagneticUncertainty
+            {
+                ModelCategory = GetModelCategory(model, null),
+                Source = UncertaintySource.WmmErrorModel,
+                Declination = declination,
+                BhDependentDec = 0,
+                TotalField = entry.TotalField,
+                DipAngle = entry.Inclination,
+                NorthIntensity = entry.NorthIntensity,
+                EastIntensity = entry.EastIntensity,
+                VerticalIntensity = entry.VerticalIntensity,
+                HorizontalIntensity = entry.HorizontalIntensity,
+                Revision = "WMM2025-TR"
+            };
+        }
+
+        /// <summary>
+        /// Computes location-dependent declination uncertainty: δD = √(C₁² + (C₂/H)²).
+        /// </summary>
+        /// <param name="declinationBase">C₁ — base declination uncertainty (degrees).</param>
+        /// <param name="declinationCoeff">C₂ — H-dependent coefficient (nT·degrees).</param>
+        /// <param name="horizontalIntensity">H — horizontal field intensity (nT).</param>
+        /// <returns>Declination uncertainty in degrees.</returns>
+        internal static double ComputeDeclinationUncertainty(double declinationBase, double declinationCoeff, double horizontalIntensity)
+        {
+            if (horizontalIntensity <= 0)
+                return 999.0;
+
+            double baseSq = declinationBase * declinationBase;
+            double coeffTerm = declinationCoeff / horizontalIntensity;
+            double coeffSq = coeffTerm * coeffTerm;
+
+            return Math.Sqrt(baseSq + coeffSq);
+        }
+
+        /// <summary>
+        /// Determines whether the WMM error model should be used based on model type and preference.
+        /// </summary>
+        internal static bool ShouldUseWmmErrorModel(knownModels model, UncertaintyModelPreference preference)
+        {
+            bool modelHasNativeErrorModel = (model == knownModels.WMM || model == knownModels.WMMHR);
+
+            switch (preference)
+            {
+                case UncertaintyModelPreference.Auto:
+                    return modelHasNativeErrorModel;
+
+                case UncertaintyModelPreference.Native:
+                    if (!modelHasNativeErrorModel)
+                        throw new InvalidOperationException(
+                            $"UncertaintyModelPreference.Native was requested but model '{model}' has no native error model. " +
+                            "Native error models are only available for WMM and WMMHR.");
+                    return true;
+
+                case UncertaintyModelPreference.Iscwsa:
+                    return false;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static WmmErrorModelEntry ResolveWmmErrorModelEntry(knownModels model)
+        {
+            var data = _wmmData.Value;
+
+            string key;
+            switch (model)
+            {
+                case knownModels.WMM:
+                    key = "WMM2025";
+                    break;
+                case knownModels.WMMHR:
+                    key = "WMMHR2025";
+                    break;
+                default:
+                    return null;
+            }
+
+            if (data.Models != null && data.Models.ContainsKey(key))
+                return data.Models[key];
+
+            return null;
+        }
+
+        private static UncertaintyData LoadIscwsaData()
+        {
+            return LoadEmbeddedResource<UncertaintyData>("GeoMagSharp.Data.iscwsa-uncertainty.json");
+        }
+
+        private static WmmErrorModelData LoadWmmData()
+        {
+            return LoadEmbeddedResource<WmmErrorModelData>("GeoMagSharp.Data.wmm-error-model.json");
+        }
+
+        private static T LoadEmbeddedResource<T>(string resourceName)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = "GeoMagSharp.Data.iscwsa-uncertainty.json";
 
             using (var stream = assembly.GetManifestResourceStream(resourceName))
             {
                 if (stream == null)
                     throw new InvalidOperationException(
-                        $"Embedded resource '{resourceName}' not found. Ensure iscwsa-uncertainty.json is set as EmbeddedResource in the project file.");
+                        $"Embedded resource '{resourceName}' not found. Ensure the JSON file is set as EmbeddedResource in the project file.");
 
                 using (var reader = new StreamReader(stream))
                 {
                     var json = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<UncertaintyData>(json);
+                    return JsonConvert.DeserializeObject<T>(json);
                 }
             }
         }

--- a/src/GeoMagSharp/UncertaintyDataProvider.cs
+++ b/src/GeoMagSharp/UncertaintyDataProvider.cs
@@ -126,7 +126,8 @@ namespace GeoMagSharp
         /// <returns>Uncertainty values with location-dependent declination.</returns>
         public static GeomagneticUncertainty GetWmmUncertainty(knownModels model, double horizontalIntensity)
         {
-            var entry = ResolveWmmErrorModelEntry(model);
+            string modelKey;
+            var entry = ResolveWmmErrorModelEntry(model, out modelKey);
 
             if (entry == null)
                 throw new InvalidOperationException(
@@ -147,7 +148,7 @@ namespace GeoMagSharp
                 EastIntensity = entry.EastIntensity,
                 VerticalIntensity = entry.VerticalIntensity,
                 HorizontalIntensity = entry.HorizontalIntensity,
-                Revision = "WMM2025-TR"
+                Revision = modelKey + "-TR"
             };
         }
 
@@ -197,25 +198,25 @@ namespace GeoMagSharp
             }
         }
 
-        private static WmmErrorModelEntry ResolveWmmErrorModelEntry(knownModels model)
+        private static WmmErrorModelEntry ResolveWmmErrorModelEntry(knownModels model, out string modelKey)
         {
             var data = _wmmData.Value;
 
-            string key;
             switch (model)
             {
                 case knownModels.WMM:
-                    key = "WMM2025";
+                    modelKey = "WMM2025";
                     break;
                 case knownModels.WMMHR:
-                    key = "WMMHR2025";
+                    modelKey = "WMMHR2025";
                     break;
                 default:
+                    modelKey = null;
                     return null;
             }
 
-            if (data.Models != null && data.Models.ContainsKey(key))
-                return data.Models[key];
+            if (data.Models != null && data.Models.ContainsKey(modelKey))
+                return data.Models[modelKey];
 
             return null;
         }

--- a/tests/GeoMagSharp.Tests/UncertaintyUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/UncertaintyUnitTest.cs
@@ -446,9 +446,9 @@ namespace GeoMagSharp_UnitTests
         }
 
         [TestMethod]
-        public void Integration_WMMCalculation_HasLowResolutionUncertainty()
+        public void Integration_WMMCalculation_DefaultAuto_UsesWmmErrorModel()
         {
-            // Arrange — load WMM2025 and run a spot calculation
+            // Arrange — load WMM2025 with default Auto preference → WMM error model
             var filePath = FindWMM2025Path();
             if (filePath == null)
                 Assert.Inconclusive("WMM2025.COF not found in TestData folder");
@@ -467,15 +467,15 @@ namespace GeoMagSharp_UnitTests
             // Act
             geoMag.MagneticCalculations(options);
 
-            // Assert
+            // Assert — with Auto, WMM now uses WMM error model
             Assert.IsTrue(geoMag.ResultsOfCalculation.Count > 0);
             var result = geoMag.ResultsOfCalculation[0];
             Assert.IsNotNull(result.Uncertainty);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Uncertainty.Source);
             Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.LowResolution, result.Uncertainty.ModelCategory);
-            Assert.AreEqual(0.36, result.Uncertainty.Declination, 0.001);
-            Assert.AreEqual(5000, result.Uncertainty.BhDependentDec, 0.1);
-            Assert.AreEqual(157, result.Uncertainty.TotalField, 0.1);
-            Assert.AreEqual(0.24, result.Uncertainty.DipAngle, 0.001);
+            Assert.AreEqual(138, result.Uncertainty.TotalField, 0.1);
+            Assert.AreEqual(0.20, result.Uncertainty.DipAngle, 0.001);
+            Assert.AreEqual(137, result.Uncertainty.NorthIntensity.Value, 0.1);
         }
 
         [TestMethod]
@@ -538,8 +538,317 @@ namespace GeoMagSharp_UnitTests
             foreach (var result in geoMag.ResultsOfCalculation)
             {
                 Assert.IsNotNull(result.Uncertainty, $"Result for {result.Date:yyyy-MM-dd} has null Uncertainty");
-                Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.LowResolution, result.Uncertainty.ModelCategory);
+                Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Uncertainty.Source);
             }
+        }
+
+        #endregion
+
+        #region WMM Error Model Tests
+
+        [TestMethod]
+        public void WmmErrorModel_WMM2025_Constants_MatchTechnicalReport()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMM, 20000);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Source);
+            Assert.AreEqual(137, result.NorthIntensity.Value, 0.1);
+            Assert.AreEqual(89, result.EastIntensity.Value, 0.1);
+            Assert.AreEqual(141, result.VerticalIntensity.Value, 0.1);
+            Assert.AreEqual(133, result.HorizontalIntensity.Value, 0.1);
+            Assert.AreEqual(138, result.TotalField, 0.1);
+            Assert.AreEqual(0.20, result.DipAngle, 0.001);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_WMMHR2025_Constants_MatchTechnicalReport()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 20000);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Source);
+            Assert.AreEqual(135, result.NorthIntensity.Value, 0.1);
+            Assert.AreEqual(85, result.EastIntensity.Value, 0.1);
+            Assert.AreEqual(134, result.VerticalIntensity.Value, 0.1);
+            Assert.AreEqual(130, result.HorizontalIntensity.Value, 0.1);
+            Assert.AreEqual(134, result.TotalField, 0.1);
+            Assert.AreEqual(0.19, result.DipAngle, 0.001);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_DeclinationUncertainty_OhioLocation()
+        {
+            // WMMHR2025 at H ≈ 19,982 nT: δD = √(0.25² + (5205/19982)²) ≈ 0.361°
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 19982);
+
+            Assert.AreEqual(0.361, result.Declination, 0.002);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_DeclinationUncertainty_HighH_ApproachesBase()
+        {
+            // At very high H (equatorial max ~41875 nT), δD approaches but doesn't equal C₁
+            // δD = √(0.25² + (5205/41875)²) = √(0.0625 + 0.01546) ≈ 0.279°
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 41875);
+
+            Assert.AreEqual(0.279, result.Declination, 0.005);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_DeclinationUncertainty_LowH_Increases()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 2000);
+
+            Assert.IsTrue(result.Declination > 2.0, "δD should be large near magnetic poles");
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_DeclinationUncertainty_ZeroH_Returns999()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 0);
+
+            Assert.AreEqual(999.0, result.Declination, 0.1);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_BhDependentDec_IsZero()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMM, 20000);
+
+            Assert.AreEqual(0, result.BhDependentDec, 0.001);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.InvalidOperationException))]
+        public void WmmErrorModel_IGRF_ThrowsInvalidOperation()
+        {
+            GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.IGRF, 20000);
+        }
+
+        [TestMethod]
+        public void GetUncertainty_Auto_WMM_ReturnsWmmSource()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.WMM, null,
+                GeoMagSharp.UncertaintyModelPreference.Auto, 20000);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Source);
+        }
+
+        [TestMethod]
+        public void GetUncertainty_Auto_WMMHR_ReturnsWmmSource()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.WMMHR, null,
+                GeoMagSharp.UncertaintyModelPreference.Auto, 20000);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Source);
+        }
+
+        [TestMethod]
+        public void GetUncertainty_Auto_IGRF_ReturnsIscwsaSource()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.IGRF, null,
+                GeoMagSharp.UncertaintyModelPreference.Auto, 20000);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.Iscwsa, result.Source);
+        }
+
+        [TestMethod]
+        public void GetUncertainty_Iscwsa_WMM_ReturnsIscwsaSource()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.WMM, null,
+                GeoMagSharp.UncertaintyModelPreference.Iscwsa, 20000);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.Iscwsa, result.Source);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.InvalidOperationException))]
+        public void GetUncertainty_Native_IGRF_Throws()
+        {
+            GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.IGRF, null,
+                GeoMagSharp.UncertaintyModelPreference.Native, 20000);
+        }
+
+        [TestMethod]
+        public void WmmErrorModel_ScaleTo_ScalesAllProperties()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMMHR, 20000);
+
+            var scaled = result.ScaleTo(2.0);
+
+            Assert.AreEqual(result.Declination * 2.0, scaled.Declination, 0.001);
+            Assert.AreEqual(result.TotalField * 2.0, scaled.TotalField, 0.1);
+            Assert.AreEqual(result.NorthIntensity.Value * 2.0, scaled.NorthIntensity.Value, 0.1);
+            Assert.AreEqual(result.EastIntensity.Value * 2.0, scaled.EastIntensity.Value, 0.1);
+            Assert.AreEqual(result.VerticalIntensity.Value * 2.0, scaled.VerticalIntensity.Value, 0.1);
+            Assert.AreEqual(result.HorizontalIntensity.Value * 2.0, scaled.HorizontalIntensity.Value, 0.1);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, scaled.Source);
+        }
+
+        #endregion
+
+        #region WMM Error Model Integration Tests
+
+        [TestMethod]
+        public void Integration_WMMCalculation_AutoPreference_UsesWmmErrorModel()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null)
+                Assert.Inconclusive("WMM2025.COF not found in TestData folder");
+
+            var geoMag = new GeoMagSharp.GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new GeoMagSharp.CalculationOptions
+            {
+                Latitude = 41.31,
+                Longitude = -81.33,
+                StartDate = new System.DateTime(2026, 3, 11)
+            };
+            options.SetElevation(0, GeoMagSharp.Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.Uncertainty);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Uncertainty.Source);
+            Assert.AreEqual(137, result.Uncertainty.NorthIntensity.Value, 0.1);
+            Assert.AreEqual(89, result.Uncertainty.EastIntensity.Value, 0.1);
+            Assert.AreEqual(141, result.Uncertainty.VerticalIntensity.Value, 0.1);
+            Assert.AreEqual(133, result.Uncertainty.HorizontalIntensity.Value, 0.1);
+            Assert.AreEqual(138, result.Uncertainty.TotalField, 0.1);
+            Assert.AreEqual(0.20, result.Uncertainty.DipAngle, 0.001);
+        }
+
+        [TestMethod]
+        public void Integration_WMMCalculation_AutoPreference_DeclinationMatchesNOAA()
+        {
+            // Verify δD at Ohio location: WMM2025 δD = √(0.26² + (5417/H)²)
+            var filePath = FindWMM2025Path();
+            if (filePath == null)
+                Assert.Inconclusive("WMM2025.COF not found in TestData folder");
+
+            var geoMag = new GeoMagSharp.GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new GeoMagSharp.CalculationOptions
+            {
+                Latitude = 41.31,
+                Longitude = -81.33,
+                StartDate = new System.DateTime(2026, 3, 11)
+            };
+            options.SetElevation(0, GeoMagSharp.Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            // WMM2025: δD = √(0.26² + (5417/H)²) where H ≈ 19,982 nT
+            // = √(0.0676 + 0.0735) = √(0.1411) ≈ 0.376°
+            Assert.AreEqual(0.376, result.Uncertainty.Declination, 0.02);
+        }
+
+        [TestMethod]
+        public void Integration_WMMCalculation_IscwsaOverride_PreservesIscwsaBehavior()
+        {
+            var filePath = FindWMM2025Path();
+            if (filePath == null)
+                Assert.Inconclusive("WMM2025.COF not found in TestData folder");
+
+            var geoMag = new GeoMagSharp.GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new GeoMagSharp.CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new System.DateTime(2025, 1, 1),
+                UncertaintyModel = GeoMagSharp.UncertaintyModelPreference.Iscwsa
+            };
+            options.SetElevation(0, GeoMagSharp.Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.Uncertainty);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.Iscwsa, result.Uncertainty.Source);
+            Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.LowResolution, result.Uncertainty.ModelCategory);
+            Assert.AreEqual(0.36, result.Uncertainty.Declination, 0.001);
+            Assert.AreEqual(5000, result.Uncertainty.BhDependentDec, 0.1);
+            Assert.AreEqual(157, result.Uncertainty.TotalField, 0.1);
+            Assert.AreEqual(0.24, result.Uncertainty.DipAngle, 0.001);
+        }
+
+        #endregion
+
+        #region Backward Compatibility Tests
+
+        [TestMethod]
+        public void CalculationOptions_UncertaintyModel_DefaultsToAuto()
+        {
+            var options = new GeoMagSharp.CalculationOptions();
+            Assert.AreEqual(GeoMagSharp.UncertaintyModelPreference.Auto, options.UncertaintyModel);
+        }
+
+        [TestMethod]
+        public void CalculationOptions_CopyConstructor_CopiesUncertaintyModel()
+        {
+            var original = new GeoMagSharp.CalculationOptions
+            {
+                UncertaintyModel = GeoMagSharp.UncertaintyModelPreference.Iscwsa
+            };
+            var copy = new GeoMagSharp.CalculationOptions(original);
+            Assert.AreEqual(GeoMagSharp.UncertaintyModelPreference.Iscwsa, copy.UncertaintyModel);
+        }
+
+        [TestMethod]
+        public void GetUncertainty_TwoParamOverload_AlwaysReturnsIscwsa()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.WMM, null);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.Iscwsa, result.Source);
+            Assert.AreEqual(0.36, result.Declination, 0.001);
+        }
+
+        [TestMethod]
+        public void Integration_WMMCalculation_CategoryOverride_ForcesIscwsa()
+        {
+            // When ModelCategoryOverride is set, it should force ISCWSA even with Auto
+            var filePath = FindWMM2025Path();
+            if (filePath == null)
+                Assert.Inconclusive("WMM2025.COF not found in TestData folder");
+
+            var geoMag = new GeoMagSharp.GeoMag();
+            geoMag.LoadModel(filePath);
+
+            var options = new GeoMagSharp.CalculationOptions
+            {
+                Latitude = 40.0,
+                Longitude = -105.0,
+                StartDate = new System.DateTime(2025, 1, 1),
+                ModelCategoryOverride = GeoMagSharp.GeomagneticModelCategory.InFieldReference1
+            };
+            options.SetElevation(0, GeoMagSharp.Distance.Unit.meter);
+
+            geoMag.MagneticCalculations(options);
+
+            var result = geoMag.ResultsOfCalculation[0];
+            Assert.IsNotNull(result.Uncertainty);
+            Assert.AreEqual(GeoMagSharp.UncertaintySource.Iscwsa, result.Uncertainty.Source);
+            Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.InFieldReference1, result.Uncertainty.ModelCategory);
+            Assert.AreEqual(0.15, result.Uncertainty.Declination, 0.001);
         }
 
         #endregion

--- a/tests/GeoMagSharp.Tests/UncertaintyUnitTest.cs
+++ b/tests/GeoMagSharp.Tests/UncertaintyUnitTest.cs
@@ -44,7 +44,7 @@ namespace GeoMagSharp_UnitTests
                 Declination = 0.36,
                 BhDependentDec = 5000,
                 TotalField = 157,
-                DipAngle = 0.24,
+                Inclination = 0.24,
                 Revision = "Rev5.13"
             };
 
@@ -55,7 +55,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.72, scaled.Declination, 0.001);
             Assert.AreEqual(10000, scaled.BhDependentDec, 0.1);
             Assert.AreEqual(314, scaled.TotalField, 0.1);
-            Assert.AreEqual(0.48, scaled.DipAngle, 0.001);
+            Assert.AreEqual(0.48, scaled.Inclination, 0.001);
             Assert.AreEqual("Rev5.13", scaled.Revision);
             Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.LowResolution, scaled.ModelCategory);
         }
@@ -69,7 +69,7 @@ namespace GeoMagSharp_UnitTests
                 Declination = 0.36,
                 BhDependentDec = 5000,
                 TotalField = 157,
-                DipAngle = 0.24
+                Inclination = 0.24
             };
 
             // Act
@@ -79,7 +79,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.36, scaled.Declination, 0.0001);
             Assert.AreEqual(5000, scaled.BhDependentDec, 0.0001);
             Assert.AreEqual(157, scaled.TotalField, 0.0001);
-            Assert.AreEqual(0.24, scaled.DipAngle, 0.0001);
+            Assert.AreEqual(0.24, scaled.Inclination, 0.0001);
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace GeoMagSharp_UnitTests
                 Declination = 0.36,
                 BhDependentDec = 5000,
                 TotalField = 157,
-                DipAngle = 0.24
+                Inclination = 0.24
             };
 
             // Act
@@ -101,7 +101,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.0, scaled.Declination, 0.0001);
             Assert.AreEqual(0.0, scaled.BhDependentDec, 0.0001);
             Assert.AreEqual(0.0, scaled.TotalField, 0.0001);
-            Assert.AreEqual(0.0, scaled.DipAngle, 0.0001);
+            Assert.AreEqual(0.0, scaled.Inclination, 0.0001);
         }
 
         [TestMethod]
@@ -113,7 +113,7 @@ namespace GeoMagSharp_UnitTests
                 Declination = 0.36,
                 BhDependentDec = 5000,
                 TotalField = 157,
-                DipAngle = 0.24,
+                Inclination = 0.24,
                 Revision = "Rev5.13"
             };
 
@@ -198,7 +198,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.36, result.Declination, 0.001);
             Assert.AreEqual(5000, result.BhDependentDec, 0.1);
             Assert.AreEqual(157, result.TotalField, 0.1);
-            Assert.AreEqual(0.24, result.DipAngle, 0.001);
+            Assert.AreEqual(0.24, result.Inclination, 0.001);
             Assert.AreEqual("Rev5.13", result.Revision);
         }
 
@@ -213,7 +213,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.30, result.Declination, 0.001);
             Assert.AreEqual(4118, result.BhDependentDec, 0.1);
             Assert.AreEqual(107, result.TotalField, 0.1);
-            Assert.AreEqual(0.16, result.DipAngle, 0.001);
+            Assert.AreEqual(0.16, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -228,7 +228,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.36, result.Declination, 0.001);
             Assert.AreEqual(5000, result.BhDependentDec, 0.1);
             Assert.AreEqual(130, result.TotalField, 0.1);
-            Assert.AreEqual(0.20, result.DipAngle, 0.001);
+            Assert.AreEqual(0.20, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -242,7 +242,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.15, result.Declination, 0.001);
             Assert.AreEqual(1500, result.BhDependentDec, 0.1);
             Assert.AreEqual(50, result.TotalField, 0.1);
-            Assert.AreEqual(0.10, result.DipAngle, 0.001);
+            Assert.AreEqual(0.10, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -257,7 +257,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.15, result.Declination, 0.001);
             Assert.AreEqual(1500, result.BhDependentDec, 0.1);
             Assert.AreEqual(50, result.TotalField, 0.1);
-            Assert.AreEqual(0.10, result.DipAngle, 0.001);
+            Assert.AreEqual(0.10, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -365,7 +365,7 @@ namespace GeoMagSharp_UnitTests
                 Declination = 0.36,
                 BhDependentDec = 5000,
                 TotalField = 157,
-                DipAngle = 0.24,
+                Inclination = 0.24,
                 Revision = "Rev5.13"
             };
 
@@ -474,7 +474,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(GeoMagSharp.UncertaintySource.WmmErrorModel, result.Uncertainty.Source);
             Assert.AreEqual(GeoMagSharp.GeomagneticModelCategory.LowResolution, result.Uncertainty.ModelCategory);
             Assert.AreEqual(138, result.Uncertainty.TotalField, 0.1);
-            Assert.AreEqual(0.20, result.Uncertainty.DipAngle, 0.001);
+            Assert.AreEqual(0.20, result.Uncertainty.Inclination, 0.001);
             Assert.AreEqual(137, result.Uncertainty.NorthIntensity.Value, 0.1);
         }
 
@@ -559,7 +559,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(141, result.VerticalIntensity.Value, 0.1);
             Assert.AreEqual(133, result.HorizontalIntensity.Value, 0.1);
             Assert.AreEqual(138, result.TotalField, 0.1);
-            Assert.AreEqual(0.20, result.DipAngle, 0.001);
+            Assert.AreEqual(0.20, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -575,7 +575,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(134, result.VerticalIntensity.Value, 0.1);
             Assert.AreEqual(130, result.HorizontalIntensity.Value, 0.1);
             Assert.AreEqual(134, result.TotalField, 0.1);
-            Assert.AreEqual(0.19, result.DipAngle, 0.001);
+            Assert.AreEqual(0.19, result.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -728,7 +728,7 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(141, result.Uncertainty.VerticalIntensity.Value, 0.1);
             Assert.AreEqual(133, result.Uncertainty.HorizontalIntensity.Value, 0.1);
             Assert.AreEqual(138, result.Uncertainty.TotalField, 0.1);
-            Assert.AreEqual(0.20, result.Uncertainty.DipAngle, 0.001);
+            Assert.AreEqual(0.20, result.Uncertainty.Inclination, 0.001);
         }
 
         [TestMethod]
@@ -786,7 +786,65 @@ namespace GeoMagSharp_UnitTests
             Assert.AreEqual(0.36, result.Uncertainty.Declination, 0.001);
             Assert.AreEqual(5000, result.Uncertainty.BhDependentDec, 0.1);
             Assert.AreEqual(157, result.Uncertainty.TotalField, 0.1);
-            Assert.AreEqual(0.24, result.Uncertainty.DipAngle, 0.001);
+            Assert.AreEqual(0.24, result.Uncertainty.Inclination, 0.001);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentOutOfRangeException))]
+        public void ComputeDeclinationUncertainty_NegativeH_Throws()
+        {
+            GeoMagSharp.UncertaintyDataProvider.ComputeDeclinationUncertainty(0.26, 5417, -1.0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentOutOfRangeException))]
+        public void ComputeDeclinationUncertainty_NaN_Throws()
+        {
+            GeoMagSharp.UncertaintyDataProvider.ComputeDeclinationUncertainty(0.26, 5417, double.NaN);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentOutOfRangeException))]
+        public void ComputeDeclinationUncertainty_PositiveInfinity_Throws()
+        {
+            GeoMagSharp.UncertaintyDataProvider.ComputeDeclinationUncertainty(0.26, 5417, double.PositiveInfinity);
+        }
+
+        [TestMethod]
+        public void ComputeDeclinationUncertainty_ZeroH_Returns999()
+        {
+            var result = GeoMagSharp.UncertaintyDataProvider.ComputeDeclinationUncertainty(0.26, 5417, 0.0);
+            Assert.AreEqual(999.0, result, 0.001);
+        }
+
+        [TestMethod]
+        public void ScaleTo_PreservesNullNullableProperties()
+        {
+            // ISCWSA source has null NorthIntensity, EastIntensity, etc.
+            var iscwsa = GeoMagSharp.UncertaintyDataProvider.GetUncertainty(
+                GeoMagSharp.knownModels.WMM, null);
+
+            Assert.IsNull(iscwsa.NorthIntensity);
+
+            var scaled = iscwsa.ScaleTo(2.0);
+            Assert.IsNull(scaled.NorthIntensity);
+            Assert.IsNull(scaled.EastIntensity);
+            Assert.IsNull(scaled.VerticalIntensity);
+            Assert.IsNull(scaled.HorizontalIntensity);
+        }
+
+        [TestMethod]
+        public void ScaleTo_ScalesNonNullNullableProperties()
+        {
+            // WMM source has non-null component properties
+            var wmm = GeoMagSharp.UncertaintyDataProvider.GetWmmUncertainty(
+                GeoMagSharp.knownModels.WMM, 20000);
+
+            Assert.IsNotNull(wmm.NorthIntensity);
+
+            var scaled = wmm.ScaleTo(2.0);
+            Assert.AreEqual(wmm.NorthIntensity.Value * 2.0, scaled.NorthIntensity.Value, 0.1);
+            Assert.AreEqual(wmm.HorizontalIntensity.Value * 2.0, scaled.HorizontalIntensity.Value, 0.1);
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Adds the WMM native error model (Level 2) for location-dependent uncertainty estimation, implementing the formulas from the WMM2025 Technical Report Section 3.4.

- **Location-dependent δD**: `δD = √(C₁² + (C₂/H)²)` — declination uncertainty varies with horizontal intensity H
- **Full 7-component uncertainty**: δX, δY, δZ, δH, δF, δI, δD (vs ISCWSA's 4 components)
- **WMM2025 and WMMHR2025 constants** from the official technical report
- **`UncertaintyModelPreference` enum**: `Auto` (default, uses WMM for WMM/WMMHR models), `Iscwsa` (force ISCWSA), `Native` (force WMM error model)
- **Backward compatible**: existing `GetUncertainty(model, override)` 2-param overload still returns ISCWSA values
- **Defensive hardening**: input validation for NaN/Infinity/negative H, null-check on deserialization, 999.0 sentinel at H=0

### Breaking Changes

- **`DipAngle` → `Inclination` rename**: `GeomagneticUncertainty.DipAngle` is now `[Obsolete]` with a forwarding alias. Use `.Inclination` instead. `DipAngle` will be removed in a future version.
- **Internal setters**: `GeomagneticUncertainty` property setters are now `internal` — external consumers can no longer set values directly (they were never intended to).
- **`GetIscwsaUncertainty` and `GetWmmUncertainty`** changed from `public` to `internal`. Use `GetUncertainty()` instead.

### New Properties on `GeomagneticUncertainty`

| Property | Type | Description |
|----------|------|-------------|
| `Source` | `UncertaintySource` | `Iscwsa` or `WmmErrorModel` |
| `NorthIntensity` | `double?` | δX (nT), null for ISCWSA |
| `EastIntensity` | `double?` | δY (nT), null for ISCWSA |
| `VerticalIntensity` | `double?` | δZ (nT), null for ISCWSA |
| `HorizontalIntensity` | `double?` | δH (nT), null for ISCWSA |
| `Inclination` | `double` | δI (degrees), replaces `DipAngle` |

## Test plan

- [x] All 326 tests pass (2 skipped — DAT file tests, pre-existing)
- [x] Build succeeds for both net48 and netstandard2.0
- [x] WMM error model constants validated against NOAA technical report
- [x] Ohio location test matches NOAA calculator output (δD ≈ 0.36°)
- [x] Edge cases: H=0 returns 999.0 sentinel, negative H throws, NaN/Infinity throws
- [x] ScaleTo preserves null nullable properties (ISCWSA) and scales non-null (WMM)
- [x] Backward compat: 2-param GetUncertainty overload returns ISCWSA, DipAngle alias works
- [x] Ralph Loop completion (2 clean cycles)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)