### PR TITLE
docs: README accuracy fixes (IDisposable + bundled coefficients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Install-Package GeoMagSharp
 ```csharp
 using GeoMagSharp;
 
-// Load a coefficient file
-var geoMag = new GeoMag();
+// Load a coefficient file (GeoMag is IDisposable so HDGM native handles get released)
+using var geoMag = new GeoMag();
 geoMag.LoadModel("WMM2025.COF");
 
 // Configure calculation
@@ -65,8 +65,8 @@ await geoMag.SaveResultsAsync("output.txt", false, cts.Token);
 | Model | Type | Source | Included |
 |-------|------|--------|----------|
 | **WMM** | World Magnetic Model | NOAA | WMM2025.COF, WMM2015.COF |
-| **WMMHR** | WMM High Resolution | NOAA | WMMHR.COF |
-| **IGRF** | International Geomagnetic Reference Field | IAGA | IGRF12.COF |
+| **WMMHR** | WMM High Resolution | NOAA | WMMHR.COF (WMMHR-2025) |
+| **IGRF** | International Geomagnetic Reference Field | IAGA | IGRF14.COF (through 2030), IGRF13.COF (through 2025), IGRF12.COF (through 2020) |
 | **EMM** | Enhanced Magnetic Model | NOAA | No (survey required) |
 | **BGGM** | BGS Global Geomagnetic Model | BGS | No (commercial license) |
 | **HDGM** | High Definition Geomagnetic Model | NOAA | No (user-supplied DLL, Windows-only) |


### PR DESCRIPTION
## Summary
Three small README fixes from an audit against current code/assets:

- **Quick Start** uses `using var` because `GeoMag` is `IDisposable` (added in PR #20 for HDGM native handles).
- **WMMHR row** adds `(WMMHR-2025)` so the year is visible (NOAA ships the high-res file without a year in the filename).
- **IGRF row** lists all three bundled generations (IGRF14 → 2030, IGRF13 → 2025, IGRF12 → 2020) instead of just IGRF12.

## Test plan
- [ ] Render README on GitHub and verify table formatting
- [ ] Confirm Quick Start snippet still parses as valid C# 8+

Skipped Ralph Loop given trivial docs scope (precedent: PR for one-line filter change).