### PR TITLE
fix: validate calc date against probed HDGM MaxDate (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 - **Cache round-trip dropped Tier 1 fields** (#31): `ModelDiscoveryCacheEntry` didn't carry the new metadata properties, and `ModelDiscovery`'s cache-hit reconstruction passed only the original 6 args to `ModelDescriptor`. First scan populated fields correctly; second scan (cache hit) silently returned them as null. DTO + reconstruction now plumb all 12 fields end-to-end. Cache schema bumped 2 → 5 to invalidate stale entries from prior 1.7.x test builds.
+- **HDGM silently extrapolated past `MaxDate`** (#30): `GeoMag.MagneticCalculations` already validated dates against the loaded model's `IsDateInRange`, but `HDGMModelLoader.Load` hardcoded `MaxDate = 9999.0` so the check was permissive-by-design for HDGM. The loader now invokes `HdgmDateProbe` (~8 native calls) to find the DLL's actual upper bound; falls back to the wide-permissive default if probe fails. Adds `CalculationOptions.AllowExtrapolation` (default `false`) for callers that intentionally want raw extrapolation. `GeoMag.LoadModel(INativeHdgmInvoker, ...)` gains optional `minDate` / `maxDate` parameters for tests and advanced extension scenarios.
 
 ## v1.7.1 (2026-04-29)
 

--- a/docs/features/30-validate-calculation-date/tasks.md
+++ b/docs/features/30-validate-calculation-date/tasks.md
@@ -1,0 +1,58 @@
+# Feature: Validate calculation date against loaded model's MinDate/MaxDate
+
+Issue: #30
+Branch: feature/30-validate-calculation-date
+Version: folded into 1.7.2 (merged with #31 in same release)
+
+## Problem (and surprise from investigation)
+
+The issue claims `GeoMag.MagneticCalculations` doesn't validate calculation dates against the loaded model's range. **Investigation showed the validation already exists** at `GeoMag.cs:143–158` and `:344–358` — both call `_Models.IsDateInRange(...)` and throw `GeoMagExceptionOutOfRange`.
+
+The actual root cause: `HDGMModelLoader.Load` (and `GeoMag.LoadModel(INativeHdgmInvoker, ...)`) hardcode `MaxDate = 9999.0` as a permissive fallback. The check fires correctly for WMM/IGRF/EMM/BGGM (which load realistic dates from .COF headers) but never trips for HDGM. So the user's smoke test of HDGM2019 calculating values through 2030 produced silent extrapolation.
+
+## Scope
+
+Two complementary changes:
+
+### A. Tighten HDGM `MaxDate` via probe
+
+`HDGMModelLoader.Load` now calls `HdgmDateProbe.Probe` (already used by discovery) before constructing the `MagneticModelSet`. The probe makes ~8 `hdgmcalc` calls with year-incremented dates and treats the first sentinel result as the upper bound. Result: HDGM2019 loads with realistic `MaxDate` (e.g. 2020.0 from probe vs old hardcoded 9999.0).
+
+If probe fails (corrupt DLL, LoadLibrary error), fall back to the old wide-permissive bounds — runtime sentinel inside `HDGMCalculationAdapter` is still authoritative.
+
+`GeoMag.LoadModel(INativeHdgmInvoker, ...)` (the test/extension overload) gets optional `minDate` / `maxDate` parameters with permissive defaults. Tests can specify tight ranges; existing callers unaffected.
+
+### B. Opt-in `CalculationOptions.AllowExtrapolation`
+
+New `bool AllowExtrapolation { get; set; }` on `CalculationOptions`, default `false`. When `true`, the four existing `IsDateInRange` checks in `MagneticCalculations` and `MagneticCalculationsAsync` are skipped — for research callers who explicitly want raw extrapolation.
+
+Wrap each existing `if (!_Models.IsDateInRange(...))` block in `if (!inCalculationOptions.AllowExtrapolation && !_Models.IsDateInRange(...))`.
+
+## Out of scope
+
+- Per-DLL filename-keyed date table for HDGM (probe is authoritative; filename is the regex source we already have via `HdgmDateProbe.ExtractYearFromFilename`)
+- GUI-side warning before invoking Calculate (separate GeoMagSharpGUI issue)
+
+## Tasks
+
+- [ ] Create this `tasks.md`
+- [ ] Modify `HDGMModelLoader.Load`: probe → use result for `MinDate`/`MaxDate`, fall back on null
+- [ ] Modify `GeoMag.LoadModel(INativeHdgmInvoker, ...)`: add optional `minDate` / `maxDate` parameters
+- [ ] Add `CalculationOptions.AllowExtrapolation` (auto-property, default `false`, copied in copy ctor)
+- [ ] Wrap the 4 `IsDateInRange` blocks in `GeoMag.cs` (lines ~143, 153, 344, 353) with `if (!opts.AllowExtrapolation)`
+- [ ] Tests:
+  - HDGM date past loaded `MaxDate` throws `GeoMagExceptionOutOfRange`
+  - Same scenario with `AllowExtrapolation = true` does NOT throw
+  - WMM regression: existing date-range check still trips when out of range
+  - Boundary cases: exactly at `MinDate`, exactly at `MaxDate`
+- [ ] Update CHANGELOG.md — add bullet to existing 1.7.2 "Bug Fixes" section (no version bump)
+
+## Workflow
+
+Single IMPLEMENTER pass. Same pattern as #31: small, well-scoped, no UX/security surface area changing.
+
+## Completion Criteria
+
+- [ ] All tasks above checked
+- [ ] `dotnet test -c Release` passes (existing + new)
+- [ ] Manual GUI verification: load HDGM2019, attempt calc for 2028 → `GeoMagExceptionOutOfRange`

--- a/src/GeoMagSharp/GeoMag.cs
+++ b/src/GeoMagSharp/GeoMag.cs
@@ -109,8 +109,15 @@ namespace GeoMagSharp
         /// <param name="invoker">A non-null INativeHdgmInvoker. The GeoMag instance takes
         /// ownership; disposing the GeoMag will dispose the invoker.</param>
         /// <param name="modelName">Optional display name for the model (defaults to "HDGM-CUSTOM").</param>
+        /// <param name="minDate">Lower bound of the model's valid decimal-year range (default 1900.0).
+        /// Test fakes and mocks can specify a tight bound to exercise out-of-range checks.</param>
+        /// <param name="maxDate">Upper bound of the model's valid decimal-year range (default 9999.0,
+        /// permissive). Production HDGM loads via <see cref="LoadModel(string)"/> probe this from the DLL.</param>
         /// <exception cref="ArgumentNullException">If <paramref name="invoker"/> is null.</exception>
-        public void LoadModel(INativeHdgmInvoker invoker, string modelName = "HDGM-CUSTOM")
+        public void LoadModel(INativeHdgmInvoker invoker,
+            string modelName = "HDGM-CUSTOM",
+            double minDate = 1900.0,
+            double maxDate = 9999.0)
         {
             if (invoker == null) throw new ArgumentNullException(nameof(invoker));
 
@@ -119,8 +126,8 @@ namespace GeoMagSharp
             {
                 Type = knownModels.HDGM,
                 Name = string.IsNullOrWhiteSpace(modelName) ? "HDGM-CUSTOM" : modelName,
-                MinDate = 1900.0,
-                MaxDate = 9999.0,
+                MinDate = minDate,
+                MaxDate = maxDate,
                 NativeInvoker = invoker
             };
         }
@@ -140,7 +147,7 @@ namespace GeoMagSharp
             if (_Models == null || (_Models.NativeInvoker == null && _Models.NumberOfModels.Equals(0)))
                 throw new GeoMagExceptionModelNotLoaded("Error: No models avaliable for calculation");
 
-            if (!_Models.IsDateInRange(inCalculationOptions.StartDate))
+            if (!inCalculationOptions.AllowExtrapolation && !_Models.IsDateInRange(inCalculationOptions.StartDate))
             {
                 throw new GeoMagExceptionOutOfRange(string.Format("Error: the date {0} is out of range for this model{1}The valid date range for the is {2} to {3}",
                     inCalculationOptions.StartDate.ToShortDateString(), Environment.NewLine, _Models.MinDate.ToDateTime().ToShortDateString(),
@@ -150,7 +157,7 @@ namespace GeoMagSharp
 
             if (inCalculationOptions.EndDate.Equals(DateTime.MinValue)) inCalculationOptions.EndDate = inCalculationOptions.StartDate;
 
-            if (!_Models.IsDateInRange(inCalculationOptions.EndDate))
+            if (!inCalculationOptions.AllowExtrapolation && !_Models.IsDateInRange(inCalculationOptions.EndDate))
             {
                 throw new GeoMagExceptionOutOfRange(string.Format("Error: the date {0} is out of range for this model{1}The valid date range for the is {2} to {3}",
                     inCalculationOptions.EndDate.ToShortDateString(), Environment.NewLine, _Models.MinDate.ToDateTime().ToShortDateString(),
@@ -341,7 +348,7 @@ namespace GeoMagSharp
             if (_Models == null || (_Models.NativeInvoker == null && _Models.NumberOfModels.Equals(0)))
                 throw new GeoMagExceptionModelNotLoaded("Error: No models avaliable for calculation");
 
-            if (!_Models.IsDateInRange(inCalculationOptions.StartDate))
+            if (!inCalculationOptions.AllowExtrapolation && !_Models.IsDateInRange(inCalculationOptions.StartDate))
             {
                 throw new GeoMagExceptionOutOfRange(string.Format("Error: the date {0} is out of range for this model{1}The valid date range for the is {2} to {3}",
                     inCalculationOptions.StartDate.ToShortDateString(), Environment.NewLine, _Models.MinDate.ToDateTime().ToShortDateString(),
@@ -350,7 +357,7 @@ namespace GeoMagSharp
 
             if (inCalculationOptions.EndDate.Equals(DateTime.MinValue)) inCalculationOptions.EndDate = inCalculationOptions.StartDate;
 
-            if (!_Models.IsDateInRange(inCalculationOptions.EndDate))
+            if (!inCalculationOptions.AllowExtrapolation && !_Models.IsDateInRange(inCalculationOptions.EndDate))
             {
                 throw new GeoMagExceptionOutOfRange(string.Format("Error: the date {0} is out of range for this model{1}The valid date range for the is {2} to {3}",
                     inCalculationOptions.EndDate.ToShortDateString(), Environment.NewLine, _Models.MinDate.ToDateTime().ToShortDateString(),

--- a/src/GeoMagSharp/HDGM/HDGMModelLoader.cs
+++ b/src/GeoMagSharp/HDGM/HDGMModelLoader.cs
@@ -8,12 +8,13 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using GeoMagSharp.Discovery;
 
 namespace GeoMagSharp.HDGM
 {
     /// <summary>
     /// Loads a NOAA HDGM DLL from a user-supplied path into a <see cref="MagneticModelSet"/>
-    /// configured with <see cref="knownModels.HDGM"/>, a permissive date range, and a
+    /// configured with <see cref="knownModels.HDGM"/>, a probed date range, and a
     /// <see cref="LoadLibraryHdgmInvoker"/> populated as the model set's NativeInvoker.
     /// </summary>
     internal static class HDGMModelLoader
@@ -33,14 +34,22 @@ namespace GeoMagSharp.HDGM
                 throw new GeoMagExceptionFileNotFound(string.Format(
                     "Error: The HDGM DLL '{0}' was not found", dllPath));
 
+            // Probe the DLL for its actual date range (#30). The probe makes ~8 hdgmcalc
+            // calls and finds the first sentinel result — authoritative for HDGM, which
+            // strips VERSIONINFO and exports no metadata. Falls back to wide-permissive
+            // bounds on probe failure (corrupt DLL, LoadLibrary error); the runtime
+            // sentinel inside HDGMCalculationAdapter remains the last-line guard.
+            var probed = HdgmDateProbe.Probe(
+                path => new LoadLibraryHdgmInvoker(path), dllPath);
+
             var invoker = new LoadLibraryHdgmInvoker(dllPath);
 
             var set = new MagneticModelSet
             {
                 Type = knownModels.HDGM,
                 Name = Path.GetFileNameWithoutExtension(dllPath).ToUpperInvariant(),
-                MinDate = 1900.0,    // wide-permissive — sentinel is authoritative
-                MaxDate = 9999.0,
+                MinDate = probed.minDate ?? 1900.0,
+                MaxDate = probed.maxDate ?? 9999.0,
                 NativeInvoker = invoker
             };
             set.FileNames.Add(Path.GetFileName(dllPath));

--- a/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
+++ b/src/GeoMagSharp/Models/Configuration/CalculationOptions.cs
@@ -38,6 +38,8 @@ namespace GeoMagSharp
             SurveyDepthMeters = null;
             WellboreAzimuthDeg = null;
             WellboreInclinationDeg = null;
+
+            AllowExtrapolation = false;
         }
 
         /// <summary>
@@ -62,6 +64,8 @@ namespace GeoMagSharp
             SurveyDepthMeters = other.SurveyDepthMeters;
             WellboreAzimuthDeg = other.WellboreAzimuthDeg;
             WellboreInclinationDeg = other.WellboreInclinationDeg;
+
+            AllowExtrapolation = other.AllowExtrapolation;
         }
 
         #endregion
@@ -109,6 +113,18 @@ namespace GeoMagSharp
         /// Wellbore inclination (degrees, 0-180). Null to skip tool-frame error calculations (Eq 5-8).
         /// </summary>
         public double? WellboreInclinationDeg { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, <see cref="GeoMag.MagneticCalculations"/> and
+        /// <see cref="GeoMag.MagneticCalculationsAsync"/> skip the date-range check
+        /// against the loaded model's <c>MinDate</c>/<c>MaxDate</c>. Default is
+        /// <c>false</c> — strict; out-of-range dates throw <c>GeoMagExceptionOutOfRange</c>.
+        /// Set to <c>true</c> only when raw extrapolation is intentional (research,
+        /// model comparison studies). The underlying calculation engine may still
+        /// produce nonsense values past the model's validity range; for HDGM the
+        /// native sentinel inside <c>HDGMCalculationAdapter</c> remains the last guard.
+        /// </summary>
+        public bool AllowExtrapolation { get; set; }
 
         #region Getters & Setters
 

--- a/src/GeoMagSharp/Models/Magnetic/MagneticModelSet.cs
+++ b/src/GeoMagSharp/Models/Magnetic/MagneticModelSet.cs
@@ -39,7 +39,7 @@ namespace GeoMagSharp
         /// <see cref="GeoMagExceptionModelNotLoaded"/>. To use HDGM with multiple GeoMag
         /// instances, load the DLL separately into each (via
         /// <see cref="GeoMag.LoadModel(string)"/> or
-        /// <see cref="GeoMag.LoadModel(INativeHdgmInvoker, string)"/>).
+        /// <see cref="GeoMag.LoadModel(INativeHdgmInvoker, string, double, double)"/>).
         /// </remarks>
         /// <param name="other">The source model set to copy.</param>
         public MagneticModelSet(MagneticModelSet other)

--- a/tests/GeoMagSharp.Tests/HDGM/GeoMagHDGMRoutingTests.cs
+++ b/tests/GeoMagSharp.Tests/HDGM/GeoMagHDGMRoutingTests.cs
@@ -155,5 +155,147 @@ namespace GeoMagSharp_UnitTests.HDGM
                 // This test mainly verifies the no-modelName overload doesn't throw.
             }
         }
+
+        // ───────── #30: HDGM date-range validation ─────────
+        // Before #30, HDGM loads hardcoded MaxDate=9999, so the existing
+        // IsDateInRange check never tripped. The fix probes the DLL for its
+        // real MaxDate (via HDGMModelLoader) and adds an opt-in
+        // AllowExtrapolation flag for callers who explicitly want raw
+        // extrapolation. These tests use the LoadModel(invoker, ..., minDate, maxDate)
+        // overload to inject tight bounds without needing a real DLL.
+
+        private const double TightMinDate = 2018.0;
+        private const double TightMaxDate = 2020.0;
+
+        private static GeoMag NewGeoMagWithTightBounds()
+        {
+            var fake = new FakeHdgmInvoker { CannedOutData = new double[25], CannedReturnValue = 0 };
+            var geo = new GeoMag();
+            geo.LoadModel(fake, "HDGM-TIGHT", minDate: TightMinDate, maxDate: TightMaxDate);
+            return geo;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(GeoMagExceptionOutOfRange))]
+        public void MagneticCalculations_StartDatePastMaxDate_ThrowsOutOfRange()
+        {
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2025, 6, 1)
+                });
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(GeoMagExceptionOutOfRange))]
+        public void MagneticCalculations_StartDateBeforeMinDate_ThrowsOutOfRange()
+        {
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2010, 6, 1)
+                });
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(GeoMagExceptionOutOfRange))]
+        public void MagneticCalculations_EndDatePastMaxDate_ThrowsOutOfRange()
+        {
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2019, 1, 1),
+                    EndDate = new DateTime(2025, 1, 1)
+                });
+            }
+        }
+
+        [TestMethod]
+        public void MagneticCalculations_AllowExtrapolation_BypassesDateCheck()
+        {
+            // Same scenario that throws above; with AllowExtrapolation=true the
+            // check is skipped and the calculation proceeds (FakeHdgmInvoker
+            // returns canned data — real DLL would extrapolate or sentinel).
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2025, 6, 1),
+                    AllowExtrapolation = true
+                });
+                Assert.AreEqual(1, geo.ResultsOfCalculation.Count,
+                    "AllowExtrapolation=true must skip date check and produce results");
+            }
+        }
+
+        [TestMethod]
+        public void MagneticCalculations_StartDateJustInsideMaxDate_DoesNotThrow()
+        {
+            // 2019-12-31 → decimal-year ~2019.9986 (day 364.5 / 365), just below
+            // TightMaxDate=2020.0. Confirms the inclusive upper-bound check holds
+            // for dates that DO fall inside the model's validity range.
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2019, 12, 31)
+                });
+                Assert.AreEqual(1, geo.ResultsOfCalculation.Count);
+            }
+        }
+
+        [TestMethod]
+        public void MagneticCalculations_StartDateJustInsideMinDate_DoesNotThrow()
+        {
+            // 2018-06-01 → decimal-year ~2018.42, well inside [2018.0, 2020.0].
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                geo.MagneticCalculations(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2018, 6, 1)
+                });
+                Assert.AreEqual(1, geo.ResultsOfCalculation.Count);
+            }
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task MagneticCalculationsAsync_StartDatePastMaxDate_ThrowsOutOfRange()
+        {
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                await Assert.ThrowsExceptionAsync<GeoMagExceptionOutOfRange>(() =>
+                    geo.MagneticCalculationsAsync(new CalculationOptions
+                    {
+                        Latitude = 40.0, Longitude = -100.0,
+                        StartDate = new DateTime(2025, 6, 1)
+                    }));
+            }
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task MagneticCalculationsAsync_AllowExtrapolation_BypassesDateCheck()
+        {
+            using (var geo = NewGeoMagWithTightBounds())
+            {
+                await geo.MagneticCalculationsAsync(new CalculationOptions
+                {
+                    Latitude = 40.0, Longitude = -100.0,
+                    StartDate = new DateTime(2025, 6, 1),
+                    AllowExtrapolation = true
+                });
+                Assert.AreEqual(1, geo.ResultsOfCalculation.Count);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes HDGM silently extrapolating past its validity end (#30). The pre-flight date-range check in `MagneticCalculations` already existed, but `HDGMModelLoader.Load` hardcoded `MaxDate = 9999.0` so the check was permissive-by-design for HDGM only. WMM/IGRF/EMM/BGGM weren't affected — their loaders pull realistic bounds from `.COF` headers.

Folds into the in-flight **1.7.2** release alongside #31 (no version bump).

Closes #30.

## Root cause

| Model | `MaxDate` source (before fix) | Pre-flight check trips? |
|---|---|---|
| WMM/WMMHR/EMM/BGGM/IGRF/DGRF | parsed from `.COF` header | yes (correctly) |
| **HDGM** | **hardcoded `9999.0`** in `HDGMModelLoader` | **never** |

The runtime sentinel inside `HDGMCalculationAdapter` (`outData[0] == -99999.0`) was the only HDGM guard, but the NOAA DLL doesn't always set it for past-validity dates — instead it extrapolates and returns plausible-looking values that consumers can't distinguish from real ones.

## Fix

Three coordinated changes:

1. **Probe-based HDGM `MaxDate`** — `HDGMModelLoader.Load` now invokes `HdgmDateProbe` (already used by `ModelDiscovery`) before constructing the `MagneticModelSet`. Probe makes ~8 `hdgmcalc` calls with year-incremented dates and treats the first sentinel as the upper bound. ~50–100 ms cost paid once per model load. Falls back to wide-permissive bounds if probe fails (corrupt DLL, LoadLibrary error).
2. **`CalculationOptions.AllowExtrapolation`** (default `false`) — opt-in flag for callers who intentionally want raw extrapolation past the model's validity range (research / model comparison). When `true`, all four existing `IsDateInRange` checks (sync + async paths, `StartDate` + `EndDate`) are skipped.
3. **`GeoMag.LoadModel(INativeHdgmInvoker, ...)`** — adds optional `minDate` / `maxDate` parameters (defaults preserve existing behavior). Lets tests and advanced extension scenarios specify tight bounds without a real DLL.

## API surface

**Additive only** — no breaking changes:
- `CalculationOptions.AllowExtrapolation { get; set; }` — new bool, default `false`
- `GeoMag.LoadModel(INativeHdgmInvoker, string, double, double)` — added two optional params

## Tests

8 new tests in `GeoMagHDGMRoutingTests`, all using `FakeHdgmInvoker` with tight bounds (no real DLL needed):
- StartDate past MaxDate / before MinDate → throws `GeoMagExceptionOutOfRange`
- EndDate past MaxDate (date-sweep range) → throws
- `AllowExtrapolation = true` bypasses the check
- Boundary cases just inside `[MinDate, MaxDate]` don't throw
- Async path (`MagneticCalculationsAsync`) mirrors sync path for both throw + bypass

Full suite passes (Release config).

## Out of scope

- Per-DLL filename-keyed date table for HDGM (probe is authoritative)
- GUI-side warning before invoking `Calculate` (separate GeoMagSharpGUI issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)