### PR TITLE
docs: refresh README + HDGM guide for 1.7.x state

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ await geoMag.MagneticCalculationsAsync(options, progress, cts.Token);
 await geoMag.SaveResultsAsync("output.txt", false, cts.Token);
 ```
 
+### Date-range validation
+
+By default, calculations strictly validate the requested date against the loaded model's `[MinDate, MaxDate)` range and throw `GeoMagExceptionOutOfRange` when out of bounds. For HDGM specifically, the DLL's actual upper bound is determined at load time via `HdgmDateProbe` (no more silent extrapolation past the model's validity). For research scenarios that need raw extrapolation, opt in via `CalculationOptions.AllowExtrapolation = true`.
+
 ## Supported Models
 
 | Model | Type | Source | Included |
@@ -73,41 +77,59 @@ await geoMag.SaveResultsAsync("output.txt", false, cts.Token);
 
 Bundled coefficient files are in the `coefficient/` directory. See `coefficient/NOTICE.md` for attribution and download links for non-bundled models.
 
-**HDGM** is *Windows-only* and requires a user-supplied NOAA DLL. It provides a degree-740 crustal field with per-point uncertainty estimates and a high-resolution survey coverage flag. See [docs/features/hdgm-support/README.md](docs/features/hdgm-support/README.md) for setup instructions.
+**HDGM** is *Windows-only* and requires a user-supplied NOAA DLL. It provides a high-degree crustal field (720 for HDGM2017–2020, 790 for HDGM2021–2025, 1040 for HDGM2026 per [CIRES](https://geomag.colorado.edu/geomagnetic-and-electric-field-models)) with per-point uncertainty estimates and a high-resolution survey coverage flag. The library detects the loaded version from the filename and probes the DLL for its actual date range. See [docs/features/hdgm-support/README.md](docs/features/hdgm-support/README.md) for setup instructions.
 
 ### Uncertainty Estimation
 
-GeoMagSharp includes ISCWSA-based geomagnetic uncertainty values (CDR-SM-03 Rev 8, Rev5.13).
-Uncertainty is automatically attached to calculation results based on the loaded model type.
+Uncertainty is auto-populated on each calculation result. Three sources contribute, selected automatically by model type (overridable via `CalculationOptions.UncertaintyPreference`):
+
+| Source | Used by | Coverage |
+|---|---|---|
+| **WMM native error model** | WMM, WMMHR (default under `Auto`) | All seven field σ; declination σ is location-dependent: `δD = √(C₁² + (C₂/H)²)` per WMM2025-2030 Tech Report Section 3.4 |
+| **HDGM per-point** | HDGM (default; populated by the DLL) | All seven field σ; varies per coordinate, plus a `HighResolutionCoverage` flag for NSD-covered regions |
+| **ISCWSA Level 1** | IGRF, DGRF, EMM, BGGM, or any model with a `ModelCategoryOverride` | Three field σ (`Declination`, `Inclination`, `TotalField`) plus `BhDependentDec`; per-component fields stay null |
+
+Field names on `GeomagneticUncertainty` mirror `MagneticCalculations` exactly — `result.Uncertainty.Inclination` is the σ for `result.Inclination`. The `Source` enum (`Iscwsa` / `WmmErrorModel` / `Hdgm`) records provenance.
 
 ```csharp
-// Uncertainty is auto-populated on each result
 geoMag.MagneticCalculations(options);
-var result = geoMag.ResultsOfCalculation[0];
+var u = geoMag.ResultsOfCalculation[0].Uncertainty;
 
-if (result.Uncertainty != null)
-{
-    Console.WriteLine($"Category:    {result.Uncertainty.ModelCategory}");
-    Console.WriteLine($"Declination: +/-{result.Uncertainty.Declination:F2} deg (1-sigma)");
-    Console.WriteLine($"Total Field: +/-{result.Uncertainty.TotalField:F0} nT (1-sigma)");
-    Console.WriteLine($"Dip Angle:   +/-{result.Uncertainty.DipAngle:F2} deg (1-sigma)");
+Console.WriteLine($"Source:      {u.Source}");
+Console.WriteLine($"Declination: ±{u.Declination:F3}° (1σ)");
+Console.WriteLine($"Inclination: ±{u.Inclination:F3}° (1σ)");
+Console.WriteLine($"Total field: ±{u.TotalField:F0} nT (1σ)");
 
-    // Scale to approximate 2-sigma
-    var u2 = result.Uncertainty.ScaleTo(2.0);
-}
+// Per-component σ — null for ISCWSA, populated for WMM and HDGM:
+if (u.HorizontalIntensity.HasValue)
+    Console.WriteLine($"Horizontal:  ±{u.HorizontalIntensity:F0} nT (1σ)");
+if (u.NorthComp.HasValue)
+    Console.WriteLine($"North comp:  ±{u.NorthComp:F0} nT (1σ)");
 
-// Override for commercial models or in-field referencing
-var ifrOptions = new CalculationOptions
+// Scale to approximate 2σ:
+var u2 = u.ScaleTo(2.0);
+```
+
+`UncertaintyModelPreference` overrides the default selection:
+
+```csharp
+var options = new CalculationOptions
 {
     Latitude = 40.0,
     Longitude = -105.0,
     StartDate = new DateTime(2025, 7, 1),
+
+    // Auto (default): WMM/WMMHR → native error model, HDGM → per-point, others → ISCWSA
+    // Iscwsa: force ISCWSA Level 1 for all model types
+    // Native: require the native error model (throws if model has none)
+    UncertaintyPreference = UncertaintyModelPreference.Auto,
+
+    // For commercial models or in-field referencing, use ISCWSA with an explicit category:
     ModelCategoryOverride = GeomagneticModelCategory.InFieldReference1
 };
 ```
 
-Auto-detected categories: WMM/IGRF/DGRF → LowResolution, WMMHR/EMM → HighResolution.
-For BGGM, HDGM, or IFR corrections, set `ModelCategoryOverride` on `CalculationOptions`.
+Setting `ModelCategoryOverride` always selects ISCWSA (the override is meaningless for native error models). Auto-detected ISCWSA categories: WMM/IGRF/DGRF → LowResolution, WMMHR/EMM/HDGM → HighResolution.
 
 See [`examples/GeoMagSharp.Example`](examples/GeoMagSharp.Example) for a runnable smoke test.
 
@@ -132,14 +154,24 @@ See [`examples/GeoMagSharp.Example`](examples/GeoMagSharp.Example) for a runnabl
 
 ```csharp
 foreach (var d in ModelDiscovery.DiscoverModels("./coefficients"))
-    Console.WriteLine($"{d.DisplayName} ({d.DetectedType}) {d.MinDate}..{d.MaxDate}");
+    Console.WriteLine($"{d.DisplayName} ({d.DetectedType}) {d.MinDate}..{d.MaxDate}  degree={d.MaxDegree}");
 
-// e.g.   WMM-2025 (WMM)  2025..2030
-//        IGRF2025 (IGRF) 1900..2030    // latest epoch label for multi-epoch IGRF files
-//        HDGM2025 (HDGM) 2000..2030
+// e.g.   WMM-2025 (WMM)  2025..2030  degree=12
+//        IGRF2025 (IGRF) 1900..2030  degree=13     // latest epoch from multi-epoch IGRF files
+//        HDGM2019 (HDGM) 1900..2027  degree=720    // date range probed from DLL; degree from CIRES
 ```
 
-For multi-epoch IGRF/DGRF `.COF` files, `DisplayName` reflects the latest epoch (e.g. `"IGRF2025"` for IGRF14.COF), with `MinDate`/`MaxDate` covering the full validity range across all contained epochs. Single-epoch models (WMM, EMM, BGGM) report their header-stated year and a 5-year MaxDate.
+`ModelDescriptor` carries Tier 1 metadata extracted from the file:
+
+| Property | Source |
+|---|---|
+| `MaxDegree` | IGRF/DGRF: epoch header. WMM/WMMHR/EMM/BGGM: scanned from coefficient rows. HDGM: filename-keyed CIRES table (720 / 790 / 1040 by release era). |
+| `SecularVariationDegree` | IGRF/DGRF epoch header (often differs from main, e.g. 13/8 for IGRF2025). |
+| `MinAltitudeKm` / `MaxAltitudeKm` | IGRF/DGRF epoch header. Null for other formats. |
+| `ReleaseDate` | WMM/WMMHR first-line date. Null for IGRF/DGRF and HDGM. |
+| `EpochCount` | IGRF/DGRF: number of epoch header lines (e.g. 26 for IGRF14). 1 for single-epoch models. |
+
+For multi-epoch IGRF/DGRF, `DisplayName` reflects the latest epoch (e.g. `"IGRF2025"` for IGRF14.COF), with `MinDate`/`MaxDate` covering the full validity range across all contained epochs. Single-epoch models report their header-stated year and a 5-year `MaxDate`. For HDGM `.dll` files, `MinDate`/`MaxDate` are determined by probing the DLL with `hdgmcalc` at year-incremented dates until the sentinel boundary is hit.
 
 Pass `new ModelDiscoveryOptions { UseCache = true }` to populate a `.models.json` cache for fast subsequent startups. The cache is schema-versioned and auto-invalidates when classifier behavior changes between library versions.
 
@@ -156,9 +188,11 @@ Pass `new ModelDiscoveryOptions { UseCache = true }` to populate a `.models.json
 
 Each `MagneticCalculations` result contains `MagneticValue` objects with:
 - `Value` - The calculated value
-- `ChangePerYear` - Secular variation (when enabled)
+- `ChangePerYear` - Secular variation (when `SecularVariation` is enabled)
 
-Available components: `Declination`, `Inclination`, `TotalField`, `HorizontalIntensity`, `NorthComponent`, `EastComponent`, `VerticalComponent`, `GridVariation`.
+Available components: `Declination`, `Inclination`, `TotalField`, `HorizontalIntensity`, `NorthComp`, `EastComp`, `VerticalComp`.
+
+`Uncertainty` (a `GeomagneticUncertainty`) carries 1σ values under the same names — see [Uncertainty Estimation](#uncertainty-estimation).
 
 ## License
 

--- a/docs/features/hdgm-support/README.md
+++ b/docs/features/hdgm-support/README.md
@@ -62,9 +62,12 @@ using (var geo = new GeoMag())
     Console.WriteLine($"D = {r.Declination.Value:F3}°");
     Console.WriteLine($"F = {r.TotalField.Value:F1} nT");
 
-    // HDGM-specific extras (null on other models)
-    if (r.Uncertainty.SigmaD.HasValue)
-        Console.WriteLine($"σ_D = {r.Uncertainty.SigmaD:F3}°");
+    // Per-point uncertainty (HDGM populates Source = Hdgm and all 7 component σ).
+    // ISCWSA-source uncertainty leaves the per-component fields null.
+    Console.WriteLine($"Source: {r.Uncertainty.Source}");
+    Console.WriteLine($"σ_D = {r.Uncertainty.Declination:F3}°");
+    if (r.Uncertainty.NorthComp.HasValue)
+        Console.WriteLine($"σ_X = {r.Uncertainty.NorthComp:F1} nT");
     if (r.Uncertainty.HighResolutionCoverage == true)
         Console.WriteLine("Location has high-resolution NSD survey coverage");
 }
@@ -101,10 +104,34 @@ IGRF, EMM, DGRF) remain cross-platform — only HDGM is restricted.
 ## Date validity
 
 HDGM ships with model coefficients for a defined year range (e.g., HDGM2019
-covers approximately 1900–2020). GeoMagSharp does not parse the version year
-from the filename; it trusts the DLL's own validation. Dates outside the
-supported range surface as `GeoMagExceptionOutOfRange` with a descriptive
-message indicating the issue.
+covers approximately 1900–2027). GeoMagSharp probes the DLL at load time
+(`HdgmDateProbe` calls `hdgmcalc` at year-incremented dates until the
+sentinel boundary is hit) and stores the result as `MinDate`/`MaxDate` on
+the loaded model. By default, `MagneticCalculations` and
+`MagneticCalculationsAsync` validate the requested date against this range
+and throw `GeoMagExceptionOutOfRange` when out of bounds.
+
+For research scenarios that need raw extrapolation past the validity end,
+opt in via `CalculationOptions.AllowExtrapolation = true`. The HDGM DLL's
+internal sentinel (`outData[0] == -99999`) remains the last-line guard
+and surfaces as `GeoMagExceptionOutOfRange` regardless of the flag.
+
+## HDGM version detection (1.7.2+)
+
+In addition to the date probe, GeoMagSharp parses the version year from the
+filename (`hdgm{year}.dll`) to populate `ModelDescriptor.MaxDegree` from the
+[CIRES](https://geomag.colorado.edu/geomagnetic-and-electric-field-models)
+public table:
+
+| Filename year | Crustal degree |
+|---|---|
+| 2017–2020 | 720 |
+| 2021–2025 | 790 |
+| 2026 | 1040 |
+
+Files outside the CIRES-published range yield `null` for `MaxDegree`. The
+NOAA DLL itself exports no metadata (`hdgmcalc` is the only symbol), so this
+filename heuristic is the only citable path.
 
 ## Integration tests
 


### PR DESCRIPTION
## Summary

Refreshes `README.md` and `docs/features/hdgm-support/README.md` to reflect 1.7.x library state. Refresh-only per maintainer direction — no per-version subsections (CHANGELOG.md remains the chronological record), no migration section.

This is **step 1 of the 1.7.2 release** sequence. Pausing here for review of the README diff before promoting to preview/main and tagging.

## What's stale that's now fixed

### `README.md`

- **Uncertainty Estimation section** — was ISCWSA-only. Now covers three sources (ISCWSA L1, WMM native error model, HDGM per-point) under the unified `GeomagneticUncertainty` shape introduced in 1.7.2 (#13). Includes a `UncertaintyPreference` (`Auto` / `Iscwsa` / `Native`) example. Fixes stale `unc.DipAngle` reference (now `Inclination` with an `[Obsolete]` bridge).
- **Result Properties** — fixed wrong names: was `NorthComponent` / `EastComponent` / `VerticalComponent`, actual API is `NorthComp` / `EastComp` / `VerticalComp`. Removed the bogus `GridVariation` (never on `MagneticCalculations`; that was discarded `outData[7]` from HDGM). Added Uncertainty cross-reference.
- **ModelDiscovery section** — adds the Tier 1 metadata table (`MaxDegree`, `SecularVariationDegree`, `MinAltitudeKm`, `MaxAltitudeKm`, `ReleaseDate`, `EpochCount`) with per-format extraction notes from #31. Mentions HDGM's filename-keyed CIRES degree lookup + DLL date probe.
- **New Date-range validation subsection** — covers strict-by-default behavior from #30 + `CalculationOptions.AllowExtrapolation` opt-in.
- **HDGM line in Supported Models** — replaced the "degree-740" hardcode with the per-version CIRES table (720 for HDGM2017–2020, 790 for 2021–2025, 1040 for 2026) and notes filename-based version detection.

### `docs/features/hdgm-support/README.md`

- Code sample updated for the unified uncertainty fields (`r.Uncertainty.Declination` and `r.Uncertainty.NorthComp` instead of the removed `SigmaD` / `SigmaX`).
- "Date validity" section rewritten — was claiming the library "trusts the DLL's own validation", but 1.7.2's `HdgmDateProbe` actively probes the DLL at load time. Documents the new behavior + `AllowExtrapolation` opt-in.
- New "HDGM version detection (1.7.2+)" subsection with the CIRES table citation.

## What's NOT in this PR

- Version bump in `Directory.Build.props` (already at 1.7.2)
- Tag `v1.7.2` on main (will happen after merge → promotion through preview → main)
- Migration guide for `Sigma*` field renames — covered in CHANGELOG, not added to README per option (a)

## Reviewer checklist

- [ ] `README.md` reads correctly top-to-bottom
- [ ] Uncertainty examples compile mentally (no API drift)
- [ ] HDGM CIRES degree table matches your understanding
- [ ] `docs/features/hdgm-support/README.md` HDGM2019 date range (1900–2027) matches your testing

After approval, the release sequence is:
1. Merge this PR to `development`
2. PR `development` → `preview`
3. PR `preview` → `main`
4. Tag `v1.7.2` on main → triggers `release.yml` NuGet publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)